### PR TITLE
DCP-2997: Add useTudorCrown flag to nunjucks template headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ This package contains:
 - [scripts](./scripts)
   - checkTranslations script used to ensure localisation files are kept synchronised
 
+# GA4 and the Crown Logo
+
+The implementation of GA4 and the Crown Logo update are contained across multiple versions of common-express in various stages. See below for details:
+
+## 5.1.0
+
+- Contains the flag to activate the new crown logo set to true ready for go-live of that feature
+
 # Installation
 
 Clone this repository and then run

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -15,7 +15,8 @@
 
   {% block govukHeader %}
     {{ govukHeader({
-      homepageUrl: "https://www.gov.uk"
+      homepageUrl: "https://www.gov.uk",
+      useTudorCrown: true
     }) }}
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -16,7 +16,8 @@
 
   {% block govukHeader %}
     {{ govukHeader({
-      homepageUrl: "https://www.gov.uk"
+      homepageUrl: "https://www.gov.uk",
+      useTudorCrown: true
     }) }}
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The `govukHeader` components found in `base-form.njk` and `base-page.njk` have been updated to include the flag `useTudorCrown: true`

This is a backport of #330 

### Why did it change

This change is required in order to activate the new crown for Identity UIs on February 19th

### Issue tracking

- [DCP-2997](https://govukverify.atlassian.net/browse/DCP-2997)

## Checklists

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[DCP-2997]: https://govukverify.atlassian.net/browse/DCP-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ