### PR TITLE
[DFC-485] - Update CSP to include GA4 domains

### DIFF
--- a/src/lib/helmet.js
+++ b/src/lib/helmet.js
@@ -20,11 +20,16 @@ module.exports = {
         "'self'",
         "data:",
         "https://www.googletagmanager.com",
-        "https://www.google-analytics.com",
+        "*.google-analytics.com",
+        "*.analytics.google.com",
       ],
       formAction: ["*"],
       objectSrc: ["'none'"],
-      connectSrc: ["'self'", "*.google-analytics.com"],
+      connectSrc: [
+        "'self'",
+        "*.google-analytics.com",
+        "*.analytics.google.com",
+      ],
     },
   },
   dnsPrefetchControl: {


### PR DESCRIPTION
## Proposed changes

### What changed

The `helmet.js` CSP object has been extended to include GA4 domains

### Why did it change

Content Security Policy errors were appearing in the console for GA4 tracker events in the Address and KBV CRIs

### Issue tracking

- [DFC-485](https://govukverify.atlassian.net/browse/DFC-485)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[DFC-485]: https://govukverify.atlassian.net/browse/DFC-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ