### PR TITLE
added initialisation for the govuk frontend.

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -77,6 +77,9 @@
   {% block scripts %}
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});</script>
+    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+      window.GOVUKFrontend.initAll()
+      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});
+    </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -78,6 +78,9 @@
   {% block scripts %}
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});</script>
+    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+      window.GOVUKFrontend.initAll()
+      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});
+    </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/unrecoverable-error.njk
+++ b/src/components/unrecoverable-error.njk
@@ -23,6 +23,7 @@
       <p><a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ translate("error.unrecoverable.contactMeLink") }}</a></p>
   </div>
   <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+    window.GOVUKFrontend.initAll()
     window.addEventListener('load', function () {
       window
       .DI


### PR DESCRIPTION
[OJ-2570] Accessibility Fix - Focus on Error Summary

## Proposed changes

### What changed

added initialisation for the govuk frontend.
to fix the issue of the focus not being pulled to the error summary

### Issue tracking


- [OJ-2570]https://govukverify.atlassian.net/browse/OJ-2571

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2570]: https://govukverify.atlassian.net/browse/OJ-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-2570]: https://govukverify.atlassian.net/browse/OJ-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ