### PR TITLE
Add security guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+# Code of conduct for `govuk-one-login`
+
+Contributors to repositories hosted in `govuk-one-login` are expected to
+follow the Contributor Covenant Code of
+Conduct, and those working within Government are also expected to follow the Civil Service Code.
+
+## Civil Service Code
+
+The [Civil Service Code](https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code)
+
+## Contributor Covenant Code of Conduct
+
+> Note:
+>
+> - where the code of conduct says "project" we mean GDS, `govuk-one-login` and all repositories hosted within it.
+> - where the code of conduct says "maintainer" we mean `govuk-one-login` organisation owners
+> - where the code of conduct says "leadership" we mean both `govuk-one-login` organisation owners, line managers, and other leadership within GDS
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at alphagov-code-of-conduct@digital.cabinet-office.gov.uk. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Notice
+
+## What?
+
+This is the security notice for all GDS (Government Digital Service) repositories. The notice explains how vulnerabilities should be reported to GDS. At GDS there are cyber security and information assurance teams, as well as security-conscious people within the programmes, that assess and triage all reported vulnerabilities.
+
+## Reporting a Vulnerability
+
+GDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it. This notice provides details for how you can let us know about vulnerabilities, or alternatively you can view our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file which contains quick links to contact us.
+
+You can report a vulnerability to GDS through our vulnerability disclosure programme at [HackerOne](https://hackerone.com/44c348eb-e030-4273-b445-d4a2f6f83ba8/embedded_submissions/new). Alternatively, you can send an email to [report@digital.cabinet-office.gov.uk]; if you do this you may get a response from ZenDesk, which is our ticketing system.
+
+When reporting a vulnerability to us, please include:
+
+- the website, page or repository where the vulnerability can be observed
+- a brief description of the vulnerability
+- details of the steps we need to take to reproduce the vulnerability
+- non-destructive exploitation details
+
+If you are able to, please also include:
+
+- the type of vulnerability, for example, the [OWASP category](https://owasp.org/www-community/vulnerabilities/)
+- screenshots or logs showing the exploitation of the vulnerability
+
+If you are not sure if the vulnerability is genuine and exploitable, or you have found:
+
+- a non-exploitable vulnerability
+- something you think could be improved - for example, missing security headers
+- TLS configuration weaknesses - for example weak cipher suite support or the presence of TLS1.0 support
+
+Then you can still [reach out via email](mailto:report@digital.cabinet-office.gov.uk) or using the [GOV.UK contact form](https://www.gov.uk/contact/govuk).
+
+## Guidelines for reporting a vulnerability
+
+When you are investigating and reporting the vulnerability on a GDS domain or subdomain, you must not:
+
+- break the law
+- access unnecessary or excessive amounts of data
+- modify data
+- use high-intensity invasive or destructive scanning tools to find vulnerabilities
+- try a denial of service - for example overwhelming a service on GOV.UK with a high volume of requests
+- disrupt GOV.UK’s services or systems
+- tell other people about the vulnerability you have found until we have disclosed it
+- social engineer, phish or physically attack our staff or infrastructure
+- demand money to disclose a vulnerability
+
+Only submit reports about exploitable vulnerabilities through HackerOne.
+
+## Bug bounty
+
+Unfortunately, GDS doesn't offer a paid bug bounty programme. GDS will make efforts to show appreciation to people who take the time and effort to disclose vulnerabilities responsibly. We do have [an acknowledgements page for legitimate issues found by researchers](https://vdp.cabinetoffice.gov.uk/thanks.txt).
+
+# Code of Conduct
+
+GDS have a contributors code of conduct, which you can find here: [CODE_OF_CONDUCT.md]
+
+---
+
+#### Further reading and inspiration about responsible disclosure and `SECURITY.md`
+
+- <https://www.gov.uk/help/report-vulnerability>
+- <https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy/>
+- <https://www.ncsc.gov.uk/information/vulnerability-reporting>
+- <https://github.com/Trewaters/security-README>
+
+[disclosure@digital.cabinet-office.gov.uk]: mailto:disclosure@digital.cabinet-office.gov.uk
+[CODE_OF_CONDUCT.md]: https://github.com/govuk-one-login/.github/blob/master/CODE_OF_CONDUCT.md
+[OWASP category]: https://www.owasp.org/index.php/Category:OWASP_Top_Ten_2017_Project


### PR DESCRIPTION
## Proposed changes

### What changed

Add security guide and code of conduct copied from https://github.com/govuk-one-login/.github/tree/main

