### PR TITLE
[DFC-648] - Update existing GA4 feature flags and add tracker flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,18 @@ The implementation of GA4 and the Crown Logo update are contained across multipl
 
 Several environment variables are declared within the CRIs and then used within the shared code of this repository:
 
-- `GA4_ENABLED` - Feature flag to disable GA4, defaulted to `false`
-- `UA_ENABLED` - Feature flag to disable UA, defaulted to `false`
+- `GA4_ENABLED` - Feature flag to enable GA4, defaulted to `false`
+- `UA_ENABLED` - Feature flag to enable UA, defaulted to `false`
 - `UA_CONTAINER_ID` - Container ID for Universal Analytics, required for UA to work correctly. Default value is `GTM-TK92W68`
 - `GA4_CONTAINER_ID` - Container ID for GA4, required for analytics to work correctly. Default value is `GTM-KD86CMZ`
 - `ANALYTICS_COOKIE_DOMAIN` - Cookie domain to persist values throughout the different sections of the OneLogin journey. Default value is `localhost`
 - `ANALYTICS_DATA_SENSITIVE` - Redacts all form response data, defaulted to `true`. Only to be set to `false` if a journey section contains no PII in none text based form controls
+- `GA4_PAGE_VIEW_ENABLED` - Feature flag to enable GA4 page view tracking, defaulted to `true`
+- `GA4_FORM_RESPONSE_ENABLED` - Feature flag to enable GA4 form response tracking, defaulted to `true`
+- `GA4_FORM_ERROR_ENABLED` - Feature flag to enable GA4 form error tracking, defaulted to `true`
+- `GA4_FORM_CHANGE_ENABLED` - Feature flag to enable GA4 form change tracking, defaulted to `true`
+- `GA4_NAVIGATION_ENABLED` - Feature flag to enable GA4 navigation tracking, defaulted to `true`
+- `GA4_SELECT_CONTENT_ENABLED` - Feature flag to enable GA4 select content tracking, defaulted to `true`
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ The implementation of GA4 and the Crown Logo update are contained across multipl
 
 Several environment variables are declared within the CRIs and then used within the shared code of this repository:
 
-- `GA4_ENABLED` - Feature flag to enable GA4, defaulted to `false`
-- `UA_ENABLED` - Feature flag to enable UA, defaulted to `false`
+- `GA4_ENABLED` - Feature flag to enable GA4, defaulted to `"false"`
+- `UA_ENABLED` - Feature flag to enable UA, defaulted to `"false"`
 - `UA_CONTAINER_ID` - Container ID for Universal Analytics, required for UA to work correctly. Default value is `GTM-TK92W68`
 - `GA4_CONTAINER_ID` - Container ID for GA4, required for analytics to work correctly. Default value is `GTM-KD86CMZ`
 - `ANALYTICS_COOKIE_DOMAIN` - Cookie domain to persist values throughout the different sections of the OneLogin journey. Default value is `localhost`
-- `ANALYTICS_DATA_SENSITIVE` - Redacts all form response data, defaulted to `true`. Only to be set to `false` if a journey section contains no PII in none text based form controls
-- `GA4_PAGE_VIEW_ENABLED` - Feature flag to enable GA4 page view tracking, defaulted to `true`
-- `GA4_FORM_RESPONSE_ENABLED` - Feature flag to enable GA4 form response tracking, defaulted to `true`
-- `GA4_FORM_ERROR_ENABLED` - Feature flag to enable GA4 form error tracking, defaulted to `true`
-- `GA4_FORM_CHANGE_ENABLED` - Feature flag to enable GA4 form change tracking, defaulted to `true`
-- `GA4_NAVIGATION_ENABLED` - Feature flag to enable GA4 navigation tracking, defaulted to `true`
-- `GA4_SELECT_CONTENT_ENABLED` - Feature flag to enable GA4 select content tracking, defaulted to `true`
+- `ANALYTICS_DATA_SENSITIVE` - Redacts all form response data, defaulted to `"true"`. Only to be set to `"false"` if a journey section contains no PII in none text based form controls
+- `GA4_PAGE_VIEW_ENABLED` - Feature flag to enable GA4 page view tracking, defaulted to `"true"`
+- `GA4_FORM_RESPONSE_ENABLED` - Feature flag to enable GA4 form response tracking, defaulted to `"true"`
+- `GA4_FORM_ERROR_ENABLED` - Feature flag to enable GA4 form error tracking, defaulted to `"true"`
+- `GA4_FORM_CHANGE_ENABLED` - Feature flag to enable GA4 form change tracking, defaulted to `"true"`
+- `GA4_NAVIGATION_ENABLED` - Feature flag to enable GA4 navigation tracking, defaulted to `"true"`
+- `GA4_SELECT_CONTENT_ENABLED` - Feature flag to enable GA4 select content tracking, defaulted to `"true"`
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The implementation of GA4 and the Crown Logo update are contained across multipl
 
 Several environment variables are declared within the CRIs and then used within the shared code of this repository:
 
-- `GA4_DISABLED` - Feature flag to disable GA4, defaulted to `false`
-- `UA_DISABLED` - Feature flag to disable UA, defaulted to `true`
+- `GA4_ENABLED` - Feature flag to disable GA4, defaulted to `false`
+- `UA_ENABLED` - Feature flag to disable UA, defaulted to `false`
 - `UA_CONTAINER_ID` - Container ID for Universal Analytics, required for UA to work correctly. Default value is `GTM-TK92W68`
 - `GA4_CONTAINER_ID` - Container ID for GA4, required for analytics to work correctly. Default value is `GTM-KD86CMZ`
 - `ANALYTICS_COOKIE_DOMAIN` - Cookie domain to persist values throughout the different sections of the OneLogin journey. Default value is `localhost`

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "npm": ">=  8.5.*"
       },
       "peerDependencies": {
-        "@govuk-one-login/frontend-analytics": ">=2.0.1",
+        "@govuk-one-login/frontend-analytics": "3.0.0",
         "@govuk-one-login/frontend-language-toggle": ">=1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": ">=1.0.0"
       }
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-2.0.1.tgz",
-      "integrity": "sha512-8xAsQrRomVYxedFOQ8JDVdYx1JReJevSjU5EDZlcS/x3PhpCxm9DHjEqyOIvTo34zkFFoI4f2um6YkdD9IRQAg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.0.0.tgz",
+      "integrity": "sha512-zjzOlyl1mb1WhKMyROqqCxAf0GWyvMK7igdnivWSyldL9ThaqZ5U4I/vDZl2FT+jII8kbQyOK+pL2AgW+mFIJQ==",
       "peer": true,
       "dependencies": {
         "copy-webpack-plugin": "^12.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-mocha": "10.2.0",
         "eslint-plugin-prettier": "5.1.3",
+        "express": "^4.19.2",
         "hmpo-form-wizard": "13.0.0",
         "lint-staged": "15.2.7",
         "mocha": "10.6.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "sinon-chai": "3.7.0"
   },
   "peerDependencies": {
-    "@govuk-one-login/frontend-analytics": ">=2.0.1",
+    "@govuk-one-login/frontend-analytics": "3.0.0",
     "@govuk-one-login/frontend-language-toggle": ">=1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": ">=1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-mocha": "10.2.0",
     "eslint-plugin-prettier": "5.1.3",
+    "express": "^4.19.2",
     "hmpo-form-wizard": "13.0.0",
     "lint-staged": "15.2.7",
     "mocha": "10.6.0",

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -79,7 +79,21 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}",isDataSensitive:{{analyticsDataSensitive}}});
+      window.DI.appInit({
+        ga4ContainerId: "{{ga4ContainerId}}",
+        uaContainerId:"{{uaContainerId}}"},{
+          enableGa4Tracking:{{ga4Enabled}},
+          enableUaTracking:{{uaEnabled}},
+          enablePageViewTracking:{{ga4PageViewEnabled}},
+          enableFormErrorTracking:{{ga4FormErrorEnabled}},
+          enableFormChangeTracking:{{ga4FormChangeEnabled}},
+          enableFormResponseTracking:{{ga4FormResponseEnabled}},
+          enableNavigationTracking:{{ga4NavigationEnabled}},
+          enableSelectContentTracking:{{ga4SelectContentEnabled}},
+          cookieDomain:"{{analyticsCookieDomain}}",
+          isDataSensitive:{{analyticsDataSensitive}}
+        }
+      );
     </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -84,8 +84,14 @@
         ga4ContainerId: "{{ga4ContainerId}}",
         uaContainerId:"{{uaContainerId}}"
       },{
-        disableGa4Tracking:{{ga4Disabled}},
-        disableUaTracking:{{uaDisabled}},
+        enableGa4Tracking:{{ga4Enabled}},
+        enableUaTracking:{{uaEnabled}},
+        enablePageViewTracking:{{ga4PageViewEnabled}},
+        enableFormErrorTracking:{{ga4FormErrorEnabled}},
+        enableFormChangeTracking:{{ga4FormChangeEnabled}},
+        enableFormResponseTracking:{{ga4FormResponseEnabled}},
+        enableNavigationTracking:{{ga4NavigationEnabled}},
+        enableSelectContentTracking:{{ga4SelectContentEnabled}},
         cookieDomain:"{{analyticsCookieDomain}}",
         isDataSensitive:{{analyticsDataSensitive}}
       });

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -5,10 +5,28 @@ module.exports = {
     res.locals.analyticsCookieDomain = req.app.get(
       "APP.GTM.ANALYTICS_COOKIE_DOMAIN",
     );
-    res.locals.ga4Disabled = req.app.get("APP.GTM.GA4_DISABLED");
-    res.locals.uaDisabled = req.app.get("APP.GTM.UA_DISABLED");
+    res.locals.ga4Enabled = req.app.get("APP.GTM.GA4_ENABLED");
+    res.locals.uaEnabled = req.app.get("APP.GTM.UA_ENABLED");
     res.locals.analyticsDataSensitive = req.app.get(
       "APP.GTM.ANALYTICS_DATA_SENSITIVE",
+    );
+    res.locals.ga4PageViewEnabled = req.app.get(
+      "APP.GTM.GA4_PAGE_VIEW_ENABLED",
+    );
+    res.locals.ga4FormResponseEnabled = req.app.get(
+      "APP.GTM.GA4_FORM_RESPONSE_ENABLED",
+    );
+    res.locals.ga4FormErrorEnabled = req.app.get(
+      "APP.GTM.GA4_FORM_ERROR_ENABLED",
+    );
+    res.locals.ga4FormChangeEnabled = req.app.get(
+      "APP.GTM.GA4_FORM_CHANGE_ENABLED",
+    );
+    res.locals.ga4NavigationEnabled = req.app.get(
+      "APP.GTM.GA4_NAVIGATION_ENABLED",
+    );
+    res.locals.ga4SelectContentEnabled = req.app.get(
+      "APP.GTM.GA4_SELECT_CONTENT_ENABLED",
     );
     next();
   },

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -4,15 +4,27 @@ module.exports = {
     ga4ContainerId,
     uaContainerId,
     analyticsCookieDomain,
-    ga4Disabled,
-    uaDisabled,
+    ga4Enabled,
+    uaEnabled,
+    ga4PageViewEnabled,
+    ga4FormResponseEnabled,
+    ga4FormErrorEnabled,
+    ga4FormChangeEnabled,
+    ga4NavigationEnabled,
+    ga4SelectContentEnabled,
     analyticsDataSensitive,
   }) => {
     app.set("APP.GTM.GA4_CONTAINER_ID", ga4ContainerId);
     app.set("APP.GTM.ANALYTICS_COOKIE_DOMAIN", analyticsCookieDomain);
     app.set("APP.GTM.UA_CONTAINER_ID", uaContainerId);
-    app.set("APP.GTM.GA4_DISABLED", ga4Disabled);
-    app.set("APP.GTM.UA_DISABLED", uaDisabled);
+    app.set("APP.GTM.GA4_ENABLED", ga4Enabled);
+    app.set("APP.GTM.UA_ENABLED", uaEnabled);
+    app.set("APP.GTM.GA4_PAGE_VIEW_ENABLED", ga4PageViewEnabled);
+    app.set("APP.GTM.GA4_FORM_RESPONSE_ENABLED", ga4FormResponseEnabled);
+    app.set("APP.GTM.GA4_FORM_ERROR_ENABLED", ga4FormErrorEnabled);
+    app.set("APP.GTM.GA4_FORM_CHANGE_ENABLED", ga4FormChangeEnabled);
+    app.set("APP.GTM.GA4_NAVIGATION_ENABLED", ga4NavigationEnabled);
+    app.set("APP.GTM.GA4_SELECT_CONTENT_ENABLED", ga4SelectContentEnabled);
     app.set("APP.GTM.ANALYTICS_DATA_SENSITIVE", analyticsDataSensitive ?? true);
   },
 

--- a/test/lib/locals.test.js
+++ b/test/lib/locals.test.js
@@ -1,0 +1,50 @@
+const express = require("express");
+const reqres = require("reqres");
+const { setGTM } = require("../../src/lib/settings");
+const { getGTM } = require("../../src/lib/locals");
+
+describe("setGTM / getGTM", () => {
+  it("Sets express config and retrieves it", () => {
+    const TEST_ROUTE = "/test";
+    const app = express();
+    const router = express.Router();
+    router.use(getGTM);
+    router.route(TEST_ROUTE).get((req, res, next) => {
+      next();
+    });
+    setGTM({
+      app,
+      ga4ContainerId: "ga4ContainerIdTest",
+      uaContainerId: "uaContainerIdTest",
+      analyticsCookieDomain: "analyticsCookieDomainTest",
+      ga4Enabled: "ga4EnabledTest",
+      uaEnabled: "uaEnabledTest",
+      ga4PageViewEnabled: "ga4PageViewEnabledTest",
+      ga4FormResponseEnabled: "ga4FormResponseEnabledTest",
+      ga4FormErrorEnabled: "ga4FormErrorEnabledTest",
+      ga4FormChangeEnabled: "ga4FormChangeEnabledTest",
+      ga4NavigationEnabled: "ga4NavigationEnabledTest",
+      ga4SelectContentEnabled: "ga4SelectContentEnabledTest",
+      analyticsDataSensitive: "analyticsDataSensitiveTest",
+    });
+    const req = reqres.req({ url: TEST_ROUTE });
+    req.app = app;
+    const res = reqres.res();
+    router(req, res, () => {
+      res.locals.should.eql({
+        ga4ContainerId: "ga4ContainerIdTest",
+        uaContainerId: "uaContainerIdTest",
+        analyticsCookieDomain: "analyticsCookieDomainTest",
+        ga4Enabled: "ga4EnabledTest",
+        uaEnabled: "uaEnabledTest",
+        ga4PageViewEnabled: "ga4PageViewEnabledTest",
+        ga4FormResponseEnabled: "ga4FormResponseEnabledTest",
+        ga4FormErrorEnabled: "ga4FormErrorEnabledTest",
+        ga4FormChangeEnabled: "ga4FormChangeEnabledTest",
+        ga4NavigationEnabled: "ga4NavigationEnabledTest",
+        ga4SelectContentEnabled: "ga4SelectContentEnabledTest",
+        analyticsDataSensitive: "analyticsDataSensitiveTest",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

- The feature flags to enable/disable GA4 and UA have been renamed positively, switching from `ga4Disabled` to `ga4Enabled`
- Each of the trackers now has its own flag

### Why did it change

- The original naming of the global flags was confusing as it reversed the boolean value. Setting it to `true` meant that the package was turned off
- Now that the package is live, a greater level of control is needed for regressions and bugs to not have a large impact that risks a rollback being required. With these flags, if any trackers start sending PII or experiencing another issue, we can turn that tracker off but continue to collect analytics data

### Issue tracking

- [DFC-648](https://govukverify.atlassian.net/browse/DFC-648)

## Checklists

### Environment variables or secrets

- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[DFC-648]: https://govukverify.atlassian.net/browse/DFC-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ