### PR TITLE
OJ-2724: Show the error page if the `redirect_uri` is not set/`authParams` is undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "6.5.0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "6.5.0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "hmpo-logger": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "6.5.0",
+  "version": "7.0.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -10,7 +10,7 @@ module.exports = {
       description: DEFAULT_ERROR_DESCRIPTION,
     };
 
-    let redirect_uri = req.session.authParams.redirect_uri;
+    let redirect_uri = req.session?.authParams?.redirect_uri;
 
     if (err.isAxiosError) {
       const errorResponse = err?.response?.data;
@@ -23,6 +23,10 @@ module.exports = {
         error.description;
 
       redirect_uri = err?.response?.data?.redirect_uri || redirect_uri;
+    }
+
+    if (!redirect_uri) {
+      return next(new Error("Missing redirect_uri"));
     }
 
     try {

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -326,5 +326,29 @@ describe("error-handling", () => {
         expect(next).to.have.been.calledWith(err);
       });
     });
+
+    context("with a missing redirect_uri", () => {
+      beforeEach(async () => {
+        err = new Error("Missing redirect_uri");
+
+        req.session = {
+          authParams: undefined,
+        };
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.to.have.been.called;
+      });
+
+      it("should call next with err", () => {
+        expect(next).to.have.been.calledWith(
+          sinon.match
+            .instanceOf(Error)
+            .and(sinon.match.has("message", "Missing redirect_uri")),
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Proposed changes

Have been advised by Lime team to release this as a breaking change as they are uncertain of the impact it may have.

### What changed
`error-handling.js` added check to see if the `redirect_uri` is present within `redirectAsErrorToCallback` method and `redirect_uri` is undefined then display the error page.

### Why did it change
CRI's were getting the following error message: `Cannot read properties of undefined (reading 'redirect_uri')` and this was causing users to not go to an appropriate error screen. 

Some teams were adding a fix to their own [frontends](https://github.com/govuk-one-login/ipv-cri-bav-front/blob/5f3f22a211b1a3cd38d36d40b75083d0a5053c91/src/app.js#L160) but given it's happening everywhere, it's better to fix it here. 

Full error message:
```
{"@timestamp":"2024-08-19T14:56:19.443Z","level":"ERROR","message":"10.1.60.167 - /search Cannot read properties of undefined (reading 'redirect_uri')","sessionID":"<>","method":"GET","host":"ip-10-1-50-249.eu-west-2.compute.internal","label":"hmpo-app:hmpo-app","stack":["TypeError: Cannot read properties of undefined (reading 'redirect_uri')","    at redirectAsErrorToCallback (/app/node_modules/@govuk-one-login/di-ipv-cri-common-express/src/lib/error-handling.js:13:47)","    at newFn (/app/node_modules/express-async-errors/index.js:16:20)","    at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:71:5)","    at d.runFunctionInContext (/opt/dynatrace/oneagent/agent/bin/1.295.66.20240805-161707/any/nodejs/nodejsagent.js:2589:80)","    at d.runFunction (/opt/dynatrace/oneagent/agent/bin/1.295.66.20240805-161707/any/nodejs/nodejsagent.js:2577:19)","    at Layer.handle_error (/opt/dynatrace/oneagent/agent/bin/1.295.66.20240805-161707/any/nodejs/nodejsagent.js:8879:18)","    at trim_prefix (/app/node_modules/express/lib/router/index.js:326:13)","    at /app/node_modules/express/lib/router/index.js:286:9","    at Function.process_params (/app/node_modules/express/lib/router/index.js:346:12)","    at Immediate.next (/app/node_modules/express/lib/router/index.js:280:10)"],"request":"/search","template":"errors/error"}
```

**After**:
```
{"@timestamp":"2024-08-20T10:15:00.130Z","level":"ERROR","message":"127.0.0.1 - /kbv/question Missing redirect_uri","sessionID":"Hw62cF4o8N4MINvqvMlBmCvruNpj-knQ","method":"GET","host":"NZXT","label":"hmpo-app:hmpo-app","stack":["Error: Missing redirect_uri","    at redirectAsErrorToCallback (/home/ubuntu/IdeaProjects/ipv-cri-common-express/src/lib/error-handling.js:29:19)","    at newFn (/home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express-async-errors/index.js:16:20)","    at Layer.handle_error (/home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express/lib/router/layer.js:71:5)","    at trim_prefix (/home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express/lib/router/index.js:326:13)","    at /home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express/lib/router/index.js:286:9","    at Function.process_params (/home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express/lib/router/index.js:346:12)","    at Immediate.next (/home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express/lib/router/index.js:280:10)","    at Immediate.<anonymous> (/home/ubuntu/IdeaProjects/ipv-cri-kbv-front/node_modules/express/lib/router/index.js:646:15)","    at process.processImmediate (node:internal/timers:478:21)"],"request":"/kbv/question","template":"errors/error"}
```


### Issue tracking
- [OJ-2724](https://govukverify.atlassian.net/browse/OJ-2724)



[OJ-2724]: https://govukverify.atlassian.net/browse/OJ-2724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ