### PR TITLE
OJ-2833: Increase logging around session response

### DIFF
--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -2,6 +2,7 @@ const { buildRedirectUrl } = require("../../lib/oauth");
 const {
   createPersonalDataHeaders,
 } = require("@govuk-one-login/frontend-passthrough-headers");
+const logger = require("hmpo-logger").get();
 
 module.exports = {
   addAuthParamsToSession: async (req, res, next) => {
@@ -47,6 +48,14 @@ module.exports = {
             headers,
           },
         );
+
+        if (!apiResponse?.data["session_id"]) {
+          logger.warn("No session ID in session response");
+        }
+
+        if (!apiResponse?.data?.redirect_uri) {
+          logger.warn("No redirect URI in session response");
+        }
 
         req.session.tokenId = apiResponse?.data["session_id"];
         req.session.authParams.state = apiResponse?.data?.state;


### PR DESCRIPTION
## Proposed changes

### What changed

 Increase logging around session response

### Why did it change

We are seeing `Request parameter validation failed. Missing parameters: [session_id]` error in Address CRI and need to get some more visibility

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2833](https://govukverify.atlassian.net/browse/OJ-2833)

