### PR TITLE
Accessibility team: remove landmark and standardise page title

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -76,7 +76,22 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});
+      window.GOVUKFrontend.initAll()
+      window.DI.appInit({
+          ga4ContainerId: "{{ga4ContainerId}}",
+          uaContainerId:"{{uaContainerId}}"
+      },{
+          enableGa4Tracking:{{ga4Enabled}},
+          enableUaTracking:{{uaEnabled}},
+          enablePageViewTracking:{{ga4PageViewEnabled}},
+          enableFormErrorTracking:{{ga4FormErrorEnabled}},
+          enableFormChangeTracking:{{ga4FormChangeEnabled}},
+          enableFormResponseTracking:{{ga4FormResponseEnabled}},
+          enableNavigationTracking:{{ga4NavigationEnabled}},
+          enableSelectContentTracking:{{ga4SelectContentEnabled}},
+          cookieDomain:"{{analyticsCookieDomain}}",
+          isDataSensitive:{{analyticsDataSensitive}}
+      });
     </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {%- block pageTitle %}
-    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }} – GOV.UK One Login
 {%- endblock %}
 
 {% block header %}
@@ -25,10 +25,7 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-    html: translate("govuk.phaseBanner.content"),
-    attributes: {
-      "role": "complementary"
-    }
+    html: translate("govuk.phaseBanner.content")
   }) }}
   {% block backLink %}
       {% if showLanguageToggle %}
@@ -79,21 +76,7 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.DI.appInit({
-        ga4ContainerId: "{{ga4ContainerId}}",
-        uaContainerId:"{{uaContainerId}}"},{
-          enableGa4Tracking:{{ga4Enabled}},
-          enableUaTracking:{{uaEnabled}},
-          enablePageViewTracking:{{ga4PageViewEnabled}},
-          enableFormErrorTracking:{{ga4FormErrorEnabled}},
-          enableFormChangeTracking:{{ga4FormChangeEnabled}},
-          enableFormResponseTracking:{{ga4FormResponseEnabled}},
-          enableNavigationTracking:{{ga4NavigationEnabled}},
-          enableSelectContentTracking:{{ga4SelectContentEnabled}},
-          cookieDomain:"{{analyticsCookieDomain}}",
-          isDataSensitive:{{analyticsDataSensitive}}
-        }
-      );
+      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});
     </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {%- block pageTitle %}
-    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }} – GOV.UK One Login
+  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }} – GOV.UK One Login
 {%- endblock %}
 
 {% block header %}
@@ -28,34 +28,33 @@
     html: translate("govuk.phaseBanner.content")
   }) }}
   {% block backLink %}
-      {% if showLanguageToggle %}
-          {% from "frontend-language-toggle/macro.njk" import languageSelect %}
-        {{ languageSelect({
-          ariaLabel: translate("govuk.languageToggle.ariaLabel"),
-          class:'govuk-!-margin-bottom-1',
-          activeLanguage: htmlLang,
-          url: currentUrl,
-          languages: [
-            {
-              code: 'en',
-              text: translate("govuk.languageToggle.englishLanguage"),
-              visuallyHidden: translate("govuk.languageToggle.englishVisuallyHidden")
-            },
-            {
-              code:'cy',
-              text: translate("govuk.languageToggle.welshLanguage"),
-              visuallyHidden: translate("govuk.languageToggle.welshVisuallyHidden")
-            }]
-          })
-        }}
-      {% endif %}
-      {% if backLink %}
-        {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-        <span id="back">{{ govukBackLink({
+    {% if showLanguageToggle %}
+      {% from "frontend-language-toggle/macro.njk" import languageSelect %}
+      {{ languageSelect({
+        ariaLabel: translate("govuk.languageToggle.ariaLabel"),
+        class:'govuk-!-margin-bottom-1',
+        activeLanguage: htmlLang,
+        url: currentUrl,
+        languages: [
+          {
+            code: 'en',
+            text: translate("govuk.languageToggle.englishLanguage"),
+            visuallyHidden: translate("govuk.languageToggle.englishVisuallyHidden")
+          },
+          {
+            code:'cy',
+            text: translate("govuk.languageToggle.welshLanguage"),
+            visuallyHidden: translate("govuk.languageToggle.welshVisuallyHidden")
+          }]
+      }) }}
+    {% endif %}
+    {% if backLink %}
+      {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+      <span id="back">{{ govukBackLink({
           text: translate("govuk.backLink"),
           href: backLink}) }}
         </span>
-      {% endif %}
+    {% endif %}
 
   {% endblock %}
 {% endblock %}
@@ -74,23 +73,24 @@
   {% block scripts %}
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
-      window.GOVUKFrontend.initAll()
-      window.DI.appInit({
-          ga4ContainerId: "{{ga4ContainerId}}",
-          uaContainerId:"{{uaContainerId}}"
-      },{
-          enableGa4Tracking:{{ga4Enabled}},
-          enableUaTracking:{{uaEnabled}},
-          enablePageViewTracking:{{ga4PageViewEnabled}},
-          enableFormErrorTracking:{{ga4FormErrorEnabled}},
-          enableFormChangeTracking:{{ga4FormChangeEnabled}},
-          enableFormResponseTracking:{{ga4FormResponseEnabled}},
-          enableNavigationTracking:{{ga4NavigationEnabled}},
-          enableSelectContentTracking:{{ga4SelectContentEnabled}},
-          cookieDomain:"{{analyticsCookieDomain}}",
-          isDataSensitive:{{analyticsDataSensitive}}
-      });
+    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>
+        window.GOVUKFrontend.initAll()
+        window.DI.appInit({
+                ga4ContainerId: "{{ ga4ContainerId }}",
+                uaContainerId: "{{ uaContainerId }}"
+            }, {
+                enableGa4Tracking:{{ ga4Enabled }},
+                enableUaTracking:{{ uaEnabled }},
+                enablePageViewTracking:{{ ga4PageViewEnabled }},
+                enableFormErrorTracking:{{ ga4FormErrorEnabled }},
+                enableFormChangeTracking:{{ ga4FormChangeEnabled }},
+                enableFormResponseTracking:{{ ga4FormResponseEnabled }},
+                enableNavigationTracking:{{ ga4NavigationEnabled }},
+                enableSelectContentTracking:{{ ga4SelectContentEnabled }},
+                cookieDomain: "{{ analyticsCookieDomain }}",
+                isDataSensitive:{{ analyticsDataSensitive }}
+            }
+        );
     </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -76,7 +76,6 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.GOVUKFrontend.initAll()
       window.DI.appInit({
           ga4ContainerId: "{{ga4ContainerId}}",
           uaContainerId:"{{uaContainerId}}"

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -5,7 +5,8 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {%- block pageTitle %}
-  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+
+  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }} – GOV.UK One Login
 {%- endblock %}
 
 {% block header %}
@@ -27,10 +28,7 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-    html: translate("govuk.phaseBanner.content"),
-    attributes: {
-      "role": "complementary"
-    }
+    html: translate("govuk.phaseBanner.content")
   }) }}
   {% block backLink %}
       {% if showLanguageToggle %}
@@ -80,21 +78,7 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.DI.appInit({
-        ga4ContainerId: "{{ga4ContainerId}}",
-        uaContainerId:"{{uaContainerId}}"
-      },{
-        enableGa4Tracking:{{ga4Enabled}},
-        enableUaTracking:{{uaEnabled}},
-        enablePageViewTracking:{{ga4PageViewEnabled}},
-        enableFormErrorTracking:{{ga4FormErrorEnabled}},
-        enableFormChangeTracking:{{ga4FormChangeEnabled}},
-        enableFormResponseTracking:{{ga4FormResponseEnabled}},
-        enableNavigationTracking:{{ga4NavigationEnabled}},
-        enableSelectContentTracking:{{ga4SelectContentEnabled}},
-        cookieDomain:"{{analyticsCookieDomain}}",
-        isDataSensitive:{{analyticsDataSensitive}}
-      });
+      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});
     </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -31,34 +31,33 @@
     html: translate("govuk.phaseBanner.content")
   }) }}
   {% block backLink %}
-      {% if showLanguageToggle %}
-        {% from "frontend-language-toggle/macro.njk" import languageSelect %}
-        {{ languageSelect({
-          ariaLabel: translate("govuk.languageToggle.ariaLabel"),
-          class:'govuk-!-margin-bottom-1',
-          activeLanguage: htmlLang,
-          url: currentUrl,
-          languages: [
-            {
-              code: 'en',
-              text: translate("govuk.languageToggle.englishLanguage"),
-              visuallyHidden: translate("govuk.languageToggle.englishVisuallyHidden")
-            },
-            {
-              code:'cy',
-              text: translate("govuk.languageToggle.welshLanguage"),
-              visuallyHidden: translate("govuk.languageToggle.welshVisuallyHidden")
-            }]
-          })
-        }}
-      {% endif %}
-      {% if backLink %}
-        {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-        <span id="back">{{ govukBackLink({
+    {% if showLanguageToggle %}
+      {% from "frontend-language-toggle/macro.njk" import languageSelect %}
+      {{ languageSelect({
+        ariaLabel: translate("govuk.languageToggle.ariaLabel"),
+        class:'govuk-!-margin-bottom-1',
+        activeLanguage: htmlLang,
+        url: currentUrl,
+        languages: [
+          {
+            code: 'en',
+            text: translate("govuk.languageToggle.englishLanguage"),
+            visuallyHidden: translate("govuk.languageToggle.englishVisuallyHidden")
+          },
+          {
+            code:'cy',
+            text: translate("govuk.languageToggle.welshLanguage"),
+            visuallyHidden: translate("govuk.languageToggle.welshVisuallyHidden")
+          }]
+      }) }}
+    {% endif %}
+    {% if backLink %}
+      {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+      <span id="back">{{ govukBackLink({
           text: translate("govuk.backLink"),
           href: backLink}) }}
         </span>
-      {% endif %}
+    {% endif %}
 
   {% endblock %}
 {% endblock %}
@@ -76,23 +75,24 @@
   {% block scripts %}
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
-    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
-      window.GOVUKFrontend.initAll()
-      window.DI.appInit({
-          ga4ContainerId: "{{ga4ContainerId}}",
-          uaContainerId:"{{uaContainerId}}"
-      },{
-          enableGa4Tracking:{{ga4Enabled}},
-          enableUaTracking:{{uaEnabled}},
-          enablePageViewTracking:{{ga4PageViewEnabled}},
-          enableFormErrorTracking:{{ga4FormErrorEnabled}},
-          enableFormChangeTracking:{{ga4FormChangeEnabled}},
-          enableFormResponseTracking:{{ga4FormResponseEnabled}},
-          enableNavigationTracking:{{ga4NavigationEnabled}},
-          enableSelectContentTracking:{{ga4SelectContentEnabled}},
-          cookieDomain:"{{analyticsCookieDomain}}",
-          isDataSensitive:{{analyticsDataSensitive}}
-      });
+    <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>
+        window.GOVUKFrontend.initAll()
+        window.DI.appInit({
+                ga4ContainerId: "{{ ga4ContainerId }}",
+                uaContainerId: "{{ uaContainerId }}"
+            }, {
+                enableGa4Tracking:{{ ga4Enabled }},
+                enableUaTracking:{{ uaEnabled }},
+                enablePageViewTracking:{{ ga4PageViewEnabled }},
+                enableFormErrorTracking:{{ ga4FormErrorEnabled }},
+                enableFormChangeTracking:{{ ga4FormChangeEnabled }},
+                enableFormResponseTracking:{{ ga4FormResponseEnabled }},
+                enableNavigationTracking:{{ ga4NavigationEnabled }},
+                enableSelectContentTracking:{{ ga4SelectContentEnabled }},
+                cookieDomain: "{{ analyticsCookieDomain }}",
+                isDataSensitive:{{ analyticsDataSensitive }}
+            }
+        );
     </script>
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -78,7 +78,6 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.GOVUKFrontend.initAll()
       window.DI.appInit({
           ga4ContainerId: "{{ga4ContainerId}}",
           uaContainerId:"{{uaContainerId}}"

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -78,7 +78,22 @@
     <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       window.GOVUKFrontend.initAll()
-      window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}",uaContainerId:"{{uaContainerId}}"},{disableGa4Tracking:{{ga4Disabled}},disableUaTracking:{{uaDisabled}},cookieDomain:"{{analyticsCookieDomain}}"});
+      window.GOVUKFrontend.initAll()
+      window.DI.appInit({
+          ga4ContainerId: "{{ga4ContainerId}}",
+          uaContainerId:"{{uaContainerId}}"
+      },{
+          enableGa4Tracking:{{ga4Enabled}},
+          enableUaTracking:{{uaEnabled}},
+          enablePageViewTracking:{{ga4PageViewEnabled}},
+          enableFormErrorTracking:{{ga4FormErrorEnabled}},
+          enableFormChangeTracking:{{ga4FormChangeEnabled}},
+          enableFormResponseTracking:{{ga4FormResponseEnabled}},
+          enableNavigationTracking:{{ga4NavigationEnabled}},
+          enableSelectContentTracking:{{ga4SelectContentEnabled}},
+          cookieDomain:"{{analyticsCookieDomain}}",
+          isDataSensitive:{{analyticsDataSensitive}}
+      });
     </script>
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR uses the agreed standard page title format for One Login and removes the phase banner landmark. 

### What changed

<!-- Describe the changes in detail - the "what"-->
`base-form.njk` and `base-page.njk` have had:

* the extra attribute removed from the phase banner call
* the option to show the `govukServiceName` removed from the page `<title>` tag

### Why did it change

Both of these changes seek to increase the consistency of the user journey. All users, but particularly users of assistive technologies, require consistent user interfaces to build trust. 

Assistive technology users could become confused if the page title changes as this is often announced when the page loads. They may also waste time investigating the `complementary` page landmark which does not contribute to understanding how the page functions, or lead the user to journey-relevant page content or form controls.

<!-- Describe the reason these changes were made - the "why" -->


