### PR TITLE
DFC-581 - Extend the URL construction in the  middleware to handle an error being thrown.

### DIFF
--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -1,3 +1,5 @@
+const Logger = require("hmpo-logger/lib/logger");
+
 module.exports = {
   getGTM: function (req, res, next) {
     res.locals.ga4ContainerId = req.app.get("APP.GTM.GA4_CONTAINER_ID");
@@ -39,9 +41,13 @@ module.exports = {
     const toggleValue = req.app.get("APP.LANGUAGE_TOGGLE_ENABLED");
     res.locals.showLanguageToggle = toggleValue && toggleValue === "1";
     res.locals.htmlLang = req.i18n.language;
-    res.locals.currentUrl = new URL(
-      req.protocol + "://" + req.get("host") + req.originalUrl,
-    );
+    try {
+      res.locals.currentUrl = new URL(
+        req.protocol + "://" + req.get("host") + req.originalUrl,
+      );
+    } catch (e) {
+      Logger.error("Error constructing url for language toggle", e.message);
+    }
     next();
   },
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -1,4 +1,5 @@
-const Logger = require("hmpo-logger/lib/logger");
+const { PACKAGE_NAME } = require("../lib/constants");
+const logger = require("hmpo-logger").get(PACKAGE_NAME);
 
 module.exports = {
   getGTM: function (req, res, next) {
@@ -46,7 +47,7 @@ module.exports = {
         req.protocol + "://" + req.get("host") + req.originalUrl,
       );
     } catch (e) {
-      Logger.error("Error constructing url for language toggle", e.message);
+      logger.error("Error constructing url for language toggle", e.message);
     }
     next();
   },


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

As part of the latest Language Toggle improvements, the active URL is now constructed using new URL() with string concatenation. While error handling is currently handled at the middleware level, adding error handling during the URL parsing process provides a more reliable solution.

A try-catch block has been added to CE, and additional error handling will be implemented within the package itself. This ensures that users can continue to navigate as usual, even if the current URL cannot be retrieved, avoiding issues with setting the URL with the language parameters which is required for the toggle to work.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DFC-581](https://govukverify.atlassian.net/browse/DFC-581)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[DFC-581]: https://govukverify.atlassian.net/browse/DFC-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ