### PR TITLE
[DFC-742] style(742): removed margin-bottom-1 from both base-form and base-page

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -35,7 +35,7 @@
           {% from "frontend-language-toggle/macro.njk" import languageSelect %}
         {{ languageSelect({
           ariaLabel: translate("govuk.languageToggle.ariaLabel"),
-          class:'govuk-!-margin-bottom-1',
+          class:"",
           activeLanguage: htmlLang,
           url: currentUrl,
           languages: [

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -37,7 +37,7 @@
         {% from "frontend-language-toggle/macro.njk" import languageSelect %}
         {{ languageSelect({
           ariaLabel: translate("govuk.languageToggle.ariaLabel"),
-          class:'govuk-!-margin-bottom-1',
+          class:"",
           activeLanguage: htmlLang,
           url: currentUrl,
           languages: [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed class which created an inconsistency in the margins below the language toggle

### Why did it change

Fixing inconsistency

### Issue tracking

(https://govukverify.atlassian.net/browse/DFC-742)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

Verified that this is consistent across CRI and non-CRI repositories as tested on driving licence (CRI) and Mobile ID Check (non-CRI) margins match up as screenshots demonstrate.
![Screenshot 2025-01-09 at 11 26 10](https://github.com/user-attachments/assets/01b68357-f273-401b-9e4f-4c0a55444194)
![Screenshot 2025-01-09 at 11 26 22](https://github.com/user-attachments/assets/536c7875-78ff-481d-8325-f65fafdc4767)
