### PR TITLE
OJ-2927: Asynchronously generates nonce for CSP

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -124,7 +128,7 @@
         "filename": "src/lib/helmet.js",
         "hashed_secret": "175847ef942af200ff3d6485225ffa881eb614e1",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 9
       }
     ],
     "src/routes/oauth2/middleware.test.js": [
@@ -137,5 +141,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-20T16:43:10Z"
+  "generated_at": "2025-01-10T17:26:01Z"
 }

--- a/src/bootstrap/middleware/headers.js
+++ b/src/bootstrap/middleware/headers.js
@@ -2,6 +2,7 @@ const helmetLib = require("helmet");
 const nocache = require("./nocache");
 const compatibility = require("./compatibility");
 const compression = require("compression");
+const { randomBytes } = require("crypto");
 
 const setup = (
   app,
@@ -14,6 +15,17 @@ const setup = (
 ) => {
   // Security
   if (helmet) {
+    app.use((_req, res, next) => {
+      randomBytes(16, (err, randomBytes) => {
+        if (err) {
+          next(err);
+        } else {
+          res.locals.cspNonce = randomBytes.toString("hex");
+          next();
+        }
+      });
+    });
+
     app.use(helmetLib(helmet));
   } else {
     app.disable("x-powered-by");

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -12,5 +12,4 @@ The lib folder contains a variety of Express middleware functions, designed to i
 - [`redis`](./redis.js) - CloudFoundry configuration for Redis
 - [`scenario-headers`](./scenario-headers.js) - helpers for setting scenario headers, used in Wiremock browser tests
 - [`settings`](./settings.js) - helpers for assigning [`req.app`](https://expressjs.com/en/api.html#req.app) values for later use with middleware
-- [`strings`](./strings.js) - function to generate [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce), used for inlining JavaScript securely
 - [`user-ip-address`](./user-ip-address.js) - function to parse out IP from semicolon delimited [X-Forwarded-For header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)

--- a/src/lib/helmet.js
+++ b/src/lib/helmet.js
@@ -1,5 +1,3 @@
-const { generateNonce } = require("./strings");
-
 module.exports = {
   contentSecurityPolicy: {
     directives: {
@@ -7,10 +5,7 @@ module.exports = {
       styleSrc: ["'self'"],
       scriptSrc: [
         "'self'",
-        (req, res) => {
-          res.locals.cspNonce = res.locals.cspNonce || generateNonce();
-          return `'nonce-${res.locals.cspNonce}'`;
-        },
+        (_req, res) => `'nonce-${res.locals.cspNonce}'`,
         "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
         "https://www.googletagmanager.com",
         "https://www.google-analytics.com",

--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,7 +1,0 @@
-const { randomBytes } = require("crypto");
-
-module.exports = {
-  generateNonce: function generateNonce() {
-    return randomBytes(16).toString("hex");
-  },
-};


### PR DESCRIPTION
## Proposed changes

### What changed

Asynchronously generates nonce for CSP following [this guide ](https://helmetjs.github.io/faq/csp-nonce-example/)

### Why did it change

The existing implementation was synchronously generating a nonce blocking the event loop multiple times on every page. This has a negative impact on performance of the overall application

### Screenshots

Before
<img width="1233" alt="Screenshot 2025-01-10 at 5 24 45 pm" src="https://github.com/user-attachments/assets/b32bafc5-ab31-4215-88ea-690cdc5956a5" />

After
<img width="1229" alt="Screenshot 2025-01-10 at 5 25 19 pm" src="https://github.com/user-attachments/assets/1b76c578-cb70-4f2f-b928-2b6ecb96459f" />

And no CSP related errors in the console
![Screenshot 2025-01-10 at 5 20 44 pm](https://github.com/user-attachments/assets/fd0e6cca-4dde-4e8e-b25d-d930de6f6b11)


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2927](https://govukverify.atlassian.net/browse/OJ-2927)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2927]: https://govukverify.atlassian.net/browse/OJ-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ