### PR TITLE
OJ-2977: Fix - removed role from govukPhaseBanner

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -25,10 +25,7 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-    html: translate("govuk.phaseBanner.content"),
-    attributes: {
-      "role": "complementary"
-    }
+    html: translate("govuk.phaseBanner.content")
   }) }}
   {% block backLink %}
       {% if showLanguageToggle %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -27,10 +27,7 @@
     tag: {
       text: translate("govuk.phaseBanner.tag")
     },
-    html: translate("govuk.phaseBanner.content"),
-    attributes: {
-      "role": "complementary"
-    }
+    html: translate("govuk.phaseBanner.content")
   }) }}
   {% block backLink %}
       {% if showLanguageToggle %}


### PR DESCRIPTION
## Proposed changes

### What changed
- Removed `role: complementary` from `govukPhaseBanner` on base form and base page nunjuck files

### Why did it change

One of the issues found during accessibility testing found [here] (https://docs.google.com/spreadsheets/d/1wRBtzKKZK8FFXBje7UMK0y7yzuMkigOt6rK0BD3_Ou0/edit?gid=0#gid=0)

### Issue tracking

- [OJ-2977](https://govukverify.atlassian.net/browse/OJ-2977)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2977]: https://govukverify.atlassian.net/browse/OJ-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ