### PR TITLE
DCP-4450 Updated server to ensure that we set a default keepAliveTimeout of 65s

### DIFF
--- a/src/bootstrap/index.js
+++ b/src/bootstrap/index.js
@@ -56,11 +56,13 @@ const setup = (
       ...options.errors,
     });
 
-  if (options.port !== false)
-    middleware.listen(app, {
+  if (options.port !== false) {
+    const server = middleware.listen(app, {
       port: options.port || config.get("port"),
       host: options.host || config.get("host"),
     });
+    server.keepAliveTimeout = 65000;
+  }
 
   return { app, staticRouter, router, errorRouter };
 };

--- a/src/bootstrap/index.js
+++ b/src/bootstrap/index.js
@@ -56,13 +56,11 @@ const setup = (
       ...options.errors,
     });
 
-  if (options.port !== false) {
-    const server = middleware.listen(app, {
+  if (options.port !== false)
+    middleware.listen(app, {
       port: options.port || config.get("port"),
       host: options.host || config.get("host"),
     });
-    server.keepAliveTimeout = 65000;
-  }
 
   return { app, staticRouter, router, errorRouter };
 };

--- a/src/bootstrap/middleware/index.js
+++ b/src/bootstrap/middleware/index.js
@@ -124,14 +124,14 @@ const middleware = {
     app = requiredArgument("app"),
     { port = 3000, host = "0.0.0.0" } = {},
   ) {
-    const server = app.listen(port, host, () => {
+    var server = app.listen(port, host, () => {
       logger.get().info("Listening on http://:listen", {
         bind: host,
         port,
         listen: (host === "0.0.0.0" ? "localhost" : host) + ":" + port,
       });
+      server.keepAliveTimeout = 65000;
     });
-    server.keepAliveTimeout = 65000;
   },
 };
 

--- a/src/bootstrap/middleware/index.js
+++ b/src/bootstrap/middleware/index.js
@@ -124,13 +124,14 @@ const middleware = {
     app = requiredArgument("app"),
     { port = 3000, host = "0.0.0.0" } = {},
   ) {
-    app.listen(port, host, () => {
+    const server = app.listen(port, host, () => {
       logger.get().info("Listening on http://:listen", {
         bind: host,
         port,
         listen: (host === "0.0.0.0" ? "localhost" : host) + ":" + port,
       });
     });
+    server.keepAliveTimeout = 65000;
   },
 };
 


### PR DESCRIPTION
## Proposed changes

### What changed

The default keepAliveSeconds timeout of node server is 5000ms, which means that it'll close connections to clients that don't ping it regularly.  The idle_timeout of a ALB is 60 seconds, therefore connections from a ALB to a target that are quiet for between 5-60 seconds may end up with the ALB sending dead traffic.

See https://repost.aws/knowledge-center/api-gateway-500-error-vpc

### Why did it change

This was identified as part of FE Scaling, and the fix has been in place in IPV Core.

### Issue tracking

- https://govukverify.atlassian.net/browse/DCP-4451
- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

