### PR TITLE
LIME-1508 pageTitle suffix amended to GOV.UK One Login

### DIFF
--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {%- block pageTitle %}
-    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+    {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK One Login
 {%- endblock %}
 
 {% block header %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 
 {%- block pageTitle %}
-  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK
+  {{- (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }}{{ " – " + govukServiceName | safe if govukServiceName !== " " }} – GOV.UK One Login
 {%- endblock %}
 
 {% block header %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

base-form.njk and base-page.njk amended to reflect required tab title suffix change from _"... GOV.UK"_ to _"... - GOV.UK One Login"_

### Why did it change

This discrepancy was flagged in an accessibility audit which found this title suffix was inconsistent with the rest of the service. 

Evidence in ticket.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1508](https://govukverify.atlassian.net/browse/LIME-1508)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1508]: https://govukverify.atlassian.net/browse/LIME-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ