### PR TITLE
LIME-1543  Add error handling for missing authparams

### DIFF
--- a/src/bootstrap/middleware/error-handler.js
+++ b/src/bootstrap/middleware/error-handler.js
@@ -26,6 +26,10 @@ const middleware =
       backLink = null;
     }
 
+    if (err.code === "MISSING_AUTHPARAMS") {
+      err.status = err.status || 403;
+    }
+
     if (res.finished || res._headerSent) {
       const logger = require("../lib/logger").get();
       return logger.error(

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -27,6 +27,15 @@ module.exports = {
       redirect_uri = err?.response?.data?.redirect_uri || redirect_uri;
     }
 
+    if (
+      !redirect_uri &&
+      !req.session?.tokenId &&
+      !req.session?.authParams?.state
+    ) {
+      err.code = "MISSING_AUTHPARAMS";
+      return next(err);
+    }
+
     if (!redirect_uri) {
       return next(new Error("Missing redirect_uri"));
     }

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -350,5 +350,28 @@ describe("error-handling", () => {
         );
       });
     });
+
+    context("with a missing redirect_uri, tokenId, and state", () => {
+      beforeEach(async () => {
+        req.session = {
+          authParams: {
+            redirect_uri: undefined,
+            state: undefined,
+          },
+          tokenId: undefined,
+        };
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.to.have.been.called;
+      });
+      it("should call next with err MISSING_AUTHPARAMS code", () => {
+        expect(next).to.have.been.calledWith(
+          sinon.match.has("code", "MISSING_AUTHPARAMS"),
+        );
+      });
+    });
   });
 });

--- a/test/bootstrap/middleware/spec.error-handler.js
+++ b/test/bootstrap/middleware/spec.error-handler.js
@@ -226,6 +226,12 @@ describe("Error Handler", () => {
         err = {};
       });
 
+      it("should set status code to 403 for MISSING_AUTHPARAMS error", () => {
+        err = { code: "MISSING_AUTHPARAMS" };
+        errorhandler(err, req, res, next);
+        res.statusCode.should.equal(403);
+      });
+
       it("sets a default template if no template is specified", () => {
         errorhandler(err, req, res, next);
         res.render.should.have.been.calledOnce;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
When a user encounters an error on any Lime owned frontend, and their session lacks a valid redirecturl, session token and state, the system returns a more appropriate 403 Forbidden error instead of the generic 500 error.

### What changed

Validation added to error-handling.js to assign MISSING_AUTHPARAMS error code
error code validation added to error-handler.js to assign 403 error status

### Why did it change

The system returns a 403 error and redirects to the default error page which is more informative than the generic 500 error.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1543](https://govukverify.atlassian.net/browse/LIME-1543)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[LIME-1543]: https://govukverify.atlassian.net/browse/LIME-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ