### PR TITLE
Add MISSING_SESSION_DATA err handling

### DIFF
--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -27,6 +27,10 @@ module.exports = {
       redirect_uri = err?.response?.data?.redirect_uri || redirect_uri;
     }
 
+    if (err.code === "MISSING_SESSION_DATA" && err.status === 401) {
+      return next(err);
+    }
+
     if (
       !redirect_uri &&
       !req.session?.tokenId &&

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -373,5 +373,40 @@ describe("error-handling", () => {
         );
       });
     });
+
+    context("MISSING_SESSION_DATA error", () => {
+      beforeEach(() => {
+        err = {
+          code: "MISSING_SESSION_DATA",
+          status: 401,
+        };
+      });
+      it("should call next with err MISSING_SESSION_DATA code", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(next).to.have.been.calledWith({
+          code: "MISSING_SESSION_DATA",
+          status: 401,
+        });
+      });
+      it("should not call res.redirect", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(res.redirect).not.to.have.been.called;
+      });
+      it("should prioritise MISSING_SESSION_DATA before MISSING_AUTHPARAMS when error code explictly set in err ", async () => {
+        req.session = {
+          authParams: {
+            redirect_uri: undefined,
+            state: undefined,
+          },
+          tokenId: undefined,
+        };
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(res.redirect).not.to.have.been.called;
+      });
+    });
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Call `next(err)`if the err has a `code: "MISSING_SESSION_DATA"` && `status: 401`  

As this request has no session data, it will have no redirect_uri, the placement of this above returning 'Missing redirect_uri' and 'MISSING_AUTHPARAMS' is important.

### Why did it change

If a request to our CRI entry point has no session data i.e. not been through the OAuth route, we want to return a 401 MISSING_SESSION_DATA error to prevent any further processing of the request.

### Issue tracking

Linked PR with more information: https://github.com/govuk-one-login/ipv-cri-check-hmrc-front/pull/356
