### PR TITLE
Release v10.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "10.5.0",
+      "version": "10.6.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
### What changed

Creating new release which includes migration of overload-protection into Common-express. 

### Why did it change

Overload protection has more coverage if moved closer to the creation of the express app, which happens in bootstrap of common-express.
