### PR TITLE
KIWI-2249 - Add support for Device Intelligence 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Several environment variables are declared within the CRIs and then used within 
 - `GA4_FORM_CHANGE_ENABLED` - Feature flag to enable GA4 form change tracking, required
 - `GA4_NAVIGATION_ENABLED` - Feature flag to enable GA4 navigation tracking, required
 - `GA4_SELECT_CONTENT_ENABLED` - Feature flag to enable GA4 select content tracking, required
+- `DEVICE_INTELLIGENCE_ENABLED` - Feature flag to enable device intelligence fingerprint component
+- `DEVICE_INTELLIGENCE_DOMAIN` - Cookie domain for device intelligence fingerprint component, required
 
 # Installation
 

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -92,5 +92,14 @@
         }
       );
     </script>
+
+    {% if useDeviceIntelligence %}
+    <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>
+    <script type="module">
+      import { setFingerprintCookie } from "/public/javascripts/deviceIntelligence.js";
+      setFingerprintCookie("{{deviceIntelligenceDomain}}")
+    </script>
+    {% endif %}
+
   {% endblock %}
 {% endblock %}

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -95,7 +95,7 @@
 
     {% if deviceIntelligenceEnabled %}
     <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>
-    <script type="module">
+    <script type="module" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       import { setFingerprintCookie } from "/public/javascripts/deviceIntelligence.js";
       setFingerprintCookie("{{deviceIntelligenceDomain}}")
     </script>

--- a/src/components/base-form.njk
+++ b/src/components/base-form.njk
@@ -93,7 +93,7 @@
       );
     </script>
 
-    {% if useDeviceIntelligence %}
+    {% if deviceIntelligenceEnabled %}
     <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>
     <script type="module">
       import { setFingerprintCookie } from "/public/javascripts/deviceIntelligence.js";

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -92,6 +92,15 @@
         cookieDomain:"{{analyticsCookieDomain}}",
         isDataSensitive:{{analyticsDataSensitive}}
       });
+    </script> 
+
+    {% if useDeviceIntelligence %}
+    <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>
+    <script type="module">
+      import { setFingerprintCookie } from "/public/javascripts/deviceIntelligence.js";
+      setFingerprintCookie("{{deviceIntelligenceDomain}}")
     </script>
+  {% endif %}
+
   {% endblock %}
 {% endblock %}

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -92,7 +92,7 @@
         cookieDomain:"{{analyticsCookieDomain}}",
         isDataSensitive:{{analyticsDataSensitive}}
       });
-    </script> 
+    </script>
 
     {% if deviceIntelligenceEnabled %}
     <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -94,7 +94,7 @@
       });
     </script> 
 
-    {% if useDeviceIntelligence %}
+    {% if deviceIntelligenceEnabled %}
     <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>
     <script type="module">
       import { setFingerprintCookie } from "/public/javascripts/deviceIntelligence.js";

--- a/src/components/base-page.njk
+++ b/src/components/base-page.njk
@@ -96,7 +96,7 @@
 
     {% if deviceIntelligenceEnabled %}
     <script type="module" src="/public/javascripts/deviceIntelligence.js"></script>
-    <script type="module">
+    <script type="module" {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
       import { setFingerprintCookie } from "/public/javascripts/deviceIntelligence.js";
       setFingerprintCookie("{{deviceIntelligenceDomain}}")
     </script>

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -33,11 +33,12 @@ module.exports = {
     );
     next();
   },
-
+  
   getAssetPath: function (req, res, next) {
     res.locals.assetPath = req.app.get("APP.ASSET_PATH");
     next();
   },
+
   getLanguageToggle: function (req, res, next) {
     const toggleValue = req.app.get("APP.LANGUAGE_TOGGLE_ENABLED");
     res.locals.showLanguageToggle = toggleValue && toggleValue === "1";
@@ -49,6 +50,12 @@ module.exports = {
     } catch (e) {
       logger.error("Error constructing url for language toggle", e.message);
     }
+    next();
+  },
+
+  getDeviceIntelligence: function (req, res, next) {
+    res.locals.useDeviceIntelligence = req.app.get("APP.USE_DEVICE_INTELLIGENCE");
+    res.locals.deviceIntelligenceDomain = req.app.get("APP.DEVICE_INTELLIGENCE_DOMAIN");
     next();
   },
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -33,7 +33,7 @@ module.exports = {
     );
     next();
   },
-  
+
   getAssetPath: function (req, res, next) {
     res.locals.assetPath = req.app.get("APP.ASSET_PATH");
     next();
@@ -54,8 +54,12 @@ module.exports = {
   },
 
   getDeviceIntelligence: function (req, res, next) {
-    res.locals.useDeviceIntelligence = req.app.get("APP.USE_DEVICE_INTELLIGENCE");
-    res.locals.deviceIntelligenceDomain = req.app.get("APP.DEVICE_INTELLIGENCE_DOMAIN");
+    res.locals.useDeviceIntelligence = req.app.get(
+      "APP.USE_DEVICE_INTELLIGENCE",
+    );
+    res.locals.deviceIntelligenceDomain = req.app.get(
+      "APP.DEVICE_INTELLIGENCE_DOMAIN",
+    );
     next();
   },
 };

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -54,8 +54,8 @@ module.exports = {
   },
 
   getDeviceIntelligence: function (req, res, next) {
-    res.locals.useDeviceIntelligence = req.app.get(
-      "APP.USE_DEVICE_INTELLIGENCE",
+    res.locals.deviceIntelligenceEnabled = req.app.get(
+      "APP.DEVICE_INTELLIGENCE_ENABLED",
     );
     res.locals.deviceIntelligenceDomain = req.app.get(
       "APP.DEVICE_INTELLIGENCE_DOMAIN",

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -34,10 +34,10 @@ module.exports = {
 
   setDeviceIntelligence: ({
     app,
-    useDeviceIntelligence,
+    deviceIntelligenceEnabled,
     deviceIntelligenceDomain,
   }) => {
-    app.set("APP.USE_DEVICE_INTELLIGENCE", useDeviceIntelligence);
+    app.set("APP.DEVICE_INTELLIGENCE_ENABLED", deviceIntelligenceEnabled);
     app.set("APP.DEVICE_INTELLIGENCE_DOMAIN", deviceIntelligenceDomain);
   },
 };

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -32,8 +32,12 @@ module.exports = {
     app.set("APP.LANGUAGE_TOGGLE_ENABLED", showLanguageToggle);
   },
 
-  setDeviceIntelligence: ({ app, useDeviceIntelligence, deviceIntelligenceDomain }) => {
+  setDeviceIntelligence: ({
+    app,
+    useDeviceIntelligence,
+    deviceIntelligenceDomain,
+  }) => {
     app.set("APP.USE_DEVICE_INTELLIGENCE", useDeviceIntelligence);
-    app.set("APP.GTM.DEVICE_INTELLIGENCE_DOMAIN", deviceIntelligenceDomain);
+    app.set("APP.DEVICE_INTELLIGENCE_DOMAIN", deviceIntelligenceDomain);
   },
 };

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -31,4 +31,9 @@ module.exports = {
   setLanguageToggle: ({ app, showLanguageToggle }) => {
     app.set("APP.LANGUAGE_TOGGLE_ENABLED", showLanguageToggle);
   },
+
+  setDeviceIntelligence: ({ app, useDeviceIntelligence, deviceIntelligenceDomain }) => {
+    app.set("APP.USE_DEVICE_INTELLIGENCE", useDeviceIntelligence);
+    app.set("APP.GTM.DEVICE_INTELLIGENCE_DOMAIN", deviceIntelligenceDomain);
+  },
 };

--- a/test/lib/locals.test.js
+++ b/test/lib/locals.test.js
@@ -2,9 +2,12 @@ const express = require("express");
 const reqres = require("reqres");
 const sinon = require("sinon");
 const { expect } = require("chai");
-const { setGTM } = require("../../src/lib/settings");
-const { getGTM } = require("../../src/lib/locals");
-const { getLanguageToggle } = require("../../src/lib/locals");
+const { setGTM, setDeviceIntelligence } = require("../../src/lib/settings");
+const {
+  getGTM,
+  getDeviceIntelligence,
+  getLanguageToggle,
+} = require("../../src/lib/locals");
 const { PACKAGE_NAME } = require("../../src/lib/constants");
 const logger = require("hmpo-logger").get(PACKAGE_NAME);
 
@@ -49,6 +52,32 @@ describe("setGTM / getGTM", () => {
         ga4NavigationEnabled: "ga4NavigationEnabledTest",
         ga4SelectContentEnabled: "ga4SelectContentEnabledTest",
         analyticsDataSensitive: "analyticsDataSensitiveTest",
+      });
+    });
+  });
+});
+
+describe("setDeviceIntelligence / getDeviceIntelligence", () => {
+  it("Sets express config and retrieves it", () => {
+    const TEST_ROUTE = "/test";
+    const app = express();
+    const router = express.Router();
+    router.use(getDeviceIntelligence);
+    router.route(TEST_ROUTE).get((req, res, next) => {
+      next();
+    });
+    setDeviceIntelligence({
+      app,
+      useDeviceIntelligence: "useDeviceIntelligenceTest",
+      deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
+    });
+    const req = reqres.req({ url: TEST_ROUTE });
+    req.app = app;
+    const res = reqres.res();
+    router(req, res, () => {
+      res.locals.should.eql({
+        useDeviceIntelligence: "useDeviceIntelligenceTest",
+        deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
       });
     });
   });

--- a/test/lib/locals.test.js
+++ b/test/lib/locals.test.js
@@ -68,7 +68,7 @@ describe("setDeviceIntelligence / getDeviceIntelligence", () => {
     });
     setDeviceIntelligence({
       app,
-      useDeviceIntelligence: "useDeviceIntelligenceTest",
+      deviceIntelligenceEnabled: "deviceIntelligenceEnabledTest",
       deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
     });
     const req = reqres.req({ url: TEST_ROUTE });
@@ -76,7 +76,7 @@ describe("setDeviceIntelligence / getDeviceIntelligence", () => {
     const res = reqres.res();
     router(req, res, () => {
       res.locals.should.eql({
-        useDeviceIntelligence: "useDeviceIntelligenceTest",
+        deviceIntelligenceEnabled: "deviceIntelligenceEnabledTest",
         deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
       });
     });


### PR DESCRIPTION
### What changed

This PR adds support for the [GDS One Login Device Intelligence node package](https://www.npmjs.com/package/@govuk-one-login/frontend-device-intelligence).

- Base nunjuck templates updated to include new script behind a feature flag
- Added functions to set required environment variables

### Why did it change

To enable CRI teams to use the Device Intelligence package

### Issue tracking

- [KIWI-2249](https://govukverify.atlassian.net/browse/KIWI-2249)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-2249]: https://govukverify.atlassian.net/browse/KIWI-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ