### PR TITLE
KIWI-2249 - Small fix for device intelligence feature flag

### DIFF
--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -54,9 +54,8 @@ module.exports = {
   },
 
   getDeviceIntelligence: function (req, res, next) {
-    res.locals.deviceIntelligenceEnabled = req.app.get(
-      "APP.DEVICE_INTELLIGENCE_ENABLED",
-    );
+    const toggleValue = req.app.get("APP.DEVICE_INTELLIGENCE_ENABLED");
+    res.locals.deviceIntelligenceEnabled = toggleValue && toggleValue === "1";
     res.locals.deviceIntelligenceDomain = req.app.get(
       "APP.DEVICE_INTELLIGENCE_DOMAIN",
     );

--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -55,7 +55,8 @@ module.exports = {
 
   getDeviceIntelligence: function (req, res, next) {
     const toggleValue = req.app.get("APP.DEVICE_INTELLIGENCE_ENABLED");
-    res.locals.deviceIntelligenceEnabled = toggleValue && toggleValue === "1";
+    res.locals.deviceIntelligenceEnabled =
+      toggleValue && toggleValue === "true";
     res.locals.deviceIntelligenceDomain = req.app.get(
       "APP.DEVICE_INTELLIGENCE_DOMAIN",
     );

--- a/test/lib/locals.test.js
+++ b/test/lib/locals.test.js
@@ -68,7 +68,7 @@ describe("setDeviceIntelligence / getDeviceIntelligence", () => {
     });
     setDeviceIntelligence({
       app,
-      deviceIntelligenceEnabled: "1",
+      deviceIntelligenceEnabled: "true",
       deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
     });
     const req = reqres.req({ url: TEST_ROUTE });

--- a/test/lib/locals.test.js
+++ b/test/lib/locals.test.js
@@ -58,7 +58,7 @@ describe("setGTM / getGTM", () => {
 });
 
 describe("setDeviceIntelligence / getDeviceIntelligence", () => {
-  it("Sets express config and retrieves it", () => {
+  it("Sets express config with boolean toggle and retrieves it", () => {
     const TEST_ROUTE = "/test";
     const app = express();
     const router = express.Router();
@@ -68,7 +68,7 @@ describe("setDeviceIntelligence / getDeviceIntelligence", () => {
     });
     setDeviceIntelligence({
       app,
-      deviceIntelligenceEnabled: "deviceIntelligenceEnabledTest",
+      deviceIntelligenceEnabled: "1",
       deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
     });
     const req = reqres.req({ url: TEST_ROUTE });
@@ -76,7 +76,7 @@ describe("setDeviceIntelligence / getDeviceIntelligence", () => {
     const res = reqres.res();
     router(req, res, () => {
       res.locals.should.eql({
-        deviceIntelligenceEnabled: "deviceIntelligenceEnabledTest",
+        deviceIntelligenceEnabled: true,
         deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
       });
     });


### PR DESCRIPTION
### What changed

Added small fix for device intelligence feature flag - this now mirrors the implementation for the language toggle feature flag. 

It is necessary to convert the value to a boolean otherwise the condition in the nunjucks templates will always evaluate to true, as environment variables are strings. So something like `toggle=false` is actually `toggle="false"` which is **truthy**. 

### Why did it change

To enable toggling of the device intelligence function.

### Issue tracking

- [KIWI-2249](https://govukverify.atlassian.net/browse/KIWI-2249)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

[KIWI-2249]: https://govukverify.atlassian.net/browse/KIWI-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ