### PR TITLE
Release v11.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "11.1.0",
+      "version": "11.2.0",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
### What changed

Removed frontend-analytics from common express

### Why did it change

Listed as a dependancy but not used in the repo and is blocking updating CRIs to GA4
