### PR TITLE
feat: updating version to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "11.2.0",
+  "version": "12.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "11.2.0",
+      "version": "12.0.0",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "11.2.0",
+  "version": "12.0.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
What changed

Updated common express to use frontend-ui v2

Why did it change
Allows all the CRIs to import the GA4 on page load and use GA4