### PR TITLE
OJ-3474: update `frontend-ui` and `hmpo-components` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "peerDependencies": {
     "@govuk-one-login/frontend-language-toggle": ">=1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": ">=1.0.0",
-    "hmpo-components": "^7.1.0",
+    "hmpo-components": "^8.0.0",
     "hmpo-config": "4.0.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:watch": "mocha --watch"
   },
   "dependencies": {
-    "@govuk-one-login/frontend-ui": "^2.0.0",
+    "@govuk-one-login/frontend-ui": "4.3.0",
     "async": "^3.2.6",
     "compression": "^1.7.5",
     "connect-redis": "6.1.3",


### PR DESCRIPTION
## Proposed changes

Not ready to merge:
* `frontend-ui` update has not been released yet
* `package-lock.json` has not been re-generated

### What changed
`frontend-ui` has been bumped to newer `4.3.0`
`hmpo-components` has been updated to `^8.0.0`

### Why did it change
To support CRIs upgrading to `govuk-frontend` version 5.

### Issue tracking
- [OJ-3474](https://govukverify.atlassian.net/browse/OJ-3474)


[OJ-3474]: https://govukverify.atlassian.net/browse/OJ-3474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ