### PR TITLE
OJ-3642: Respect LOG_LEVEL environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,6 @@ dist
 
 # IDE files
 .idea
+.vscode
 
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "13.1.1",
+  "version": "13.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "13.1.1",
+      "version": "13.2.0",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "13.1.1",
+  "version": "13.2.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/bootstrap/lib/logger.js
+++ b/src/bootstrap/lib/logger.js
@@ -35,7 +35,7 @@ const get = (name = ":hmpo-app", level = 1) => {
   }
   let newPinoLogger = pino({
     name,
-    level: process.env.LOGS_LEVEL ?? "info",
+    level: process.env.LOG_LEVEL ?? "info",
     messageKey: "message", // rename default msg property to message,
     formatters: {
       level(label) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Made common-express use LOG_LEVEL env var instead of LOGS_LEVEL
- Bumped to v13.2.0

### Why did it change

- CRI frontends use the LOG_LEVEL environment variable to set log level, but common-express was using LOGS_LEVEL.
- I'd argue this is a bug fix in functionality that's not in regular use yet, rather than a breaking feature change, so doesn't warrant a major version bump (but open to debate on this)

### Issue tracking

- OJ-3642

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
