### PR TITLE
OJ-3669: Added more details to error logs when using pino

### DIFF
--- a/src/bootstrap/lib/logger.js
+++ b/src/bootstrap/lib/logger.js
@@ -1,6 +1,7 @@
 const hmpoLogger = require("hmpo-logger");
 const config = require("./config");
 const pino = require("pino");
+const { PACKAGE_NAME } = require("../../lib/constants");
 
 const pinoLoggers = new Map();
 
@@ -56,14 +57,46 @@ const get = (name = ":hmpo-app", level = 1) => {
           location: redactQueryParams(res.getHeader("location")),
         };
       },
+      err: (err) => {
+        return {
+          type: err.name,
+          message: err.message,
+          stack: err.stack,
+        };
+      },
     },
   });
   pinoLoggers.set(name, newPinoLogger);
   return newPinoLogger;
 };
 
+function logError(req, err, options = {}) {
+  const { messagePrefix, logger = get(PACKAGE_NAME) } = options;
+
+  if (process.env.USE_PINO_LOGGER === "true") {
+    const message = messagePrefix
+      ? `${messagePrefix}: ${err.message}`
+      : err.message;
+
+    logger.error({
+      ...(err.code && { code: err.code }),
+      method: req.method,
+      request: redactQueryParams(req.originalUrl || req.url),
+      message,
+      err,
+    });
+  } else {
+    const baseMessage = ":clientip :verb :request :err.message";
+    const message = messagePrefix
+      ? `${messagePrefix}: ${baseMessage}`
+      : baseMessage;
+    logger.error(message, { req, err });
+  }
+}
+
 module.exports = Object.assign(get, {
   setup,
   get,
   redactQueryParams,
+  logError,
 });

--- a/src/bootstrap/middleware/error-handler.js
+++ b/src/bootstrap/middleware/error-handler.js
@@ -1,3 +1,5 @@
+const logger = require("../lib/logger");
+
 const middleware =
   ({
     startUrl = "/",
@@ -31,11 +33,9 @@ const middleware =
     }
 
     if (res.finished || res._headerSent) {
-      const logger = require("../lib/logger").get();
-      return logger.error(
-        "Error after response: :clientip :verb :request :err.message",
-        { req: req, err: err },
-      );
+      return logger.logError(req, err, {
+        messagePrefix: "Error after response",
+      });
     }
 
     if (err.redirect) {
@@ -49,8 +49,7 @@ const middleware =
 
     if (!err.template) {
       err.template = defaultErrorView;
-      const logger = require("../lib/logger").get();
-      logger.error(":clientip :verb :request :err.message", { req, err });
+      logger.logError(req, err);
     }
 
     err.status = err.status || 500;

--- a/src/bootstrap/middleware/index.js
+++ b/src/bootstrap/middleware/index.js
@@ -3,6 +3,7 @@ const express = require("express");
 const logger = require("../lib/logger");
 const hmpoLogger = require("hmpo-logger");
 const pinoHttp = require("pino-http");
+const { PACKAGE_NAME } = require("../../lib/constants");
 
 const requiredArgument = (argName) => {
   throw new Error(`Argument '${argName}' must be specified`);
@@ -41,7 +42,7 @@ const addRequestContext = (req, res, val) => {
   };
 };
 
-const loggerMiddleware = (name = ":hmpo-app") =>
+const loggerMiddleware = (name = PACKAGE_NAME) =>
   pinoHttp({
     // Reuse an existing logger instance
     logger: logger.get(name),

--- a/test/bootstrap/lib/spec.logger.js
+++ b/test/bootstrap/lib/spec.logger.js
@@ -48,8 +48,8 @@ describe("Logger", () => {
   });
 
   afterEach(() => {
-    hmpoLogger.config.restore();
-    hmpoLogger.get.restore();
+    if (hmpoLogger.config.restore) hmpoLogger.config.restore();
+    if (hmpoLogger.get.restore) hmpoLogger.get.restore();
     LOGGER_RESET();
   });
 
@@ -116,6 +116,109 @@ describe("Logger", () => {
       const logger1 = logger.get("cached-logger");
       const logger2 = logger.get("cached-logger");
       expect(logger1).to.equal(logger2);
+    });
+  });
+
+  describe("logError", () => {
+    let mockLogger;
+
+    const mockReq = {
+      method: "GET",
+      url: "/search?q=test&code=sensitive",
+      originalUrl: "/search?q=test&code=sensitive",
+      ip: "127.0.0.1",
+    };
+
+    const mockErr = () => {
+      const err = new Error("Something failed");
+      err.code = "FAIL";
+      err.name = "TestError";
+      err.stack = "stacktrace";
+      return err;
+    };
+
+    beforeEach(function () {
+      sinon.restore();
+
+      process.env.USE_PINO_LOGGER = "true";
+
+      mockLogger = {
+        error: sinon.stub(),
+        info: sinon.stub(),
+        warn: sinon.stub(),
+      };
+    });
+
+    afterEach(function () {
+      sinon.restore();
+      delete process.env.USE_PINO_LOGGER;
+      delete process.env.NODE_ENV;
+    });
+
+    it("should log structured error in Pino mode", function () {
+      logger.logError(mockReq, mockErr(), { logger: mockLogger });
+
+      expect(mockLogger.error.calledOnce).to.equal(true);
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.code).to.equal("FAIL");
+      expect(arg.method).to.equal("GET");
+      expect(arg.request).to.equal("/search?q=test&code=hidden");
+      expect(arg.message.includes("Something failed")).to.equal(true);
+    });
+
+    it("should include prefix in message", function () {
+      logger.logError(mockReq, mockErr(), {
+        logger: mockLogger,
+        messagePrefix: "Added Start",
+      });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.message.startsWith("Added Start:")).to.equal(true);
+    });
+
+    it("should omit code if not present", function () {
+      const err = new Error("No code error");
+
+      logger.logError(mockReq, err, { logger: mockLogger });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.code).to.equal(undefined);
+    });
+
+    it("should redact sensitive query params from request", function () {
+      logger.logError(mockReq, mockErr(), { logger: mockLogger });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.request).to.equal("/search?q=test&code=hidden");
+    });
+
+    it("should include stack in non-production", function () {
+      process.env.NODE_ENV = "development";
+
+      logger.logError(mockReq, mockErr(), { logger: mockLogger });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.err.stack).to.exist;
+    });
+
+    it("should call HMPO logger in legacy mode", function () {
+      process.env.USE_PINO_LOGGER = "false";
+
+      logger.logError(mockReq, mockErr(), { logger: mockLogger });
+
+      expect(mockLogger.error.calledOnce).to.equal(true);
+
+      const args = mockLogger.error.firstCall.args;
+
+      expect(args[0]).to.equal(":clientip :verb :request :err.message");
+      expect(args[1].req).to.exist;
+      expect(args[1].err).to.exist;
     });
   });
 });

--- a/test/bootstrap/middleware/spec.error-handler.js
+++ b/test/bootstrap/middleware/spec.error-handler.js
@@ -1,12 +1,12 @@
-const middleware = require(
-  APP_ROOT + "/src/bootstrap/middleware/error-handler",
-).middleware;
+const loggerModule = require("../../../src/bootstrap/lib/logger");
 const request = require("hmpo-reqres").req;
 
 describe("Error Handler", () => {
-  let req, res, next, errorhandler, loggerStub;
+  let req, res, next, errorhandler, middleware;
 
   beforeEach(() => {
+    sinon.restore();
+
     req = request({
       baseUrl: "/my-app",
       path: "/my-app/path",
@@ -21,11 +21,15 @@ describe("Error Handler", () => {
     };
     next = sinon.stub();
 
+    sinon.spy(loggerModule, "logError");
+
+    middleware = require(
+      APP_ROOT + "/src/bootstrap/middleware/error-handler",
+    ).middleware;
+
     errorhandler = middleware({
       startUrl: "/start",
     });
-
-    loggerStub = LOGGER_RESET();
   });
 
   describe("middleware", () => {
@@ -252,32 +256,25 @@ describe("Error Handler", () => {
       });
 
       it("should log the error if no template is specified", () => {
-        loggerStub.error.reset();
         errorhandler(err, req, res, next);
-        loggerStub.error.should.have.been.calledOnce;
-        loggerStub.error.should.have.been.calledWithExactly(
-          ":clientip :verb :request :err.message",
-          { req: req, err: err },
-        );
+        loggerModule.logError.should.have.been.calledOnce;
+        loggerModule.logError.should.have.been.calledWithExactly(req, err);
       });
 
       it("should not log the error if a template is specified", () => {
         err.template = "test/template";
-        loggerStub.error.reset();
         errorhandler(err, req, res, next);
-        loggerStub.error.should.not.have.been.called;
+        loggerModule.logError.should.not.have.been.called;
       });
 
       it("should only log the error if the header has been sent", () => {
         res._headerSent = true;
         err.template = "test/template";
-        loggerStub.error.reset();
         errorhandler(err, req, res, next);
-        loggerStub.error.should.have.been.calledOnce;
-        loggerStub.error.should.have.been.calledWithExactly(
-          "Error after response: :clientip :verb :request :err.message",
-          { req: req, err: err },
-        );
+        loggerModule.logError.should.have.been.calledOnce;
+        loggerModule.logError.should.have.been.calledWithExactly(req, err, {
+          messagePrefix: "Error after response",
+        });
         res.render.should.not.have.been.called;
         next.should.not.have.been.called;
       });


### PR DESCRIPTION
## Proposed changes

### What changed

The `pino` logger was added, although has not been used as it is behind a feature flag. During testing it was noticed that the error logs are lacking quite a bit of information, and that the err was being logged in full on the request logging.

- Ensured the name is set on the logs (used `PACKAGE_NAME`).
- Added `logError` function that can be called to log errors with details similar to that of the `hmpo-logger`.
- Added `err` serializer on the `pino` logs to avoid potential PII being included in the logs.

Note: There is a `SENSITIVE_PARAMS` const in `logger.js`, if you have any sensitive query params in your app you should add them to this list.

### Issue tracking

- [OJ-3669](https://govukverify.atlassian.net/browse/OJ-3669)

[OJ-3669]: https://govukverify.atlassian.net/browse/OJ-3669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ