### PR TITLE
OJ-3681: Provide run ID to Sonarcloud action on main

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -34,6 +34,7 @@ jobs:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-artifact: ${{ needs.coverage.outputs.coverage-artifact || 'coverage' }}
+          coverage-run-id: ${{ github.event_name != 'pull_request' && github.run_id || null }}
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Provide run ID to Sonarcloud scan action when running outside a PR

### Why did it change

This should resolve an issue where Sonar was trying to await an artifact that had already been uploaded in the previous job. This failed only on main as PR checks do upload the artifact elsewhere.

Providing the run ID to the DI Sonarcloud action will [stop it awaiting the artifact](https://github.com/govuk-one-login/github-actions/blob/44b1a08e0c09d361058bc3707271bc36e4b1282d/code-quality/sonarcloud/action.yml#L42) and force it to directly download the artifact from the current run.

The cause of this is unknown - no related changes were made at the time that the pipeline started failing. This fix is inspired by [the equivalent action in the Check HMRC API repo](https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/blob/main/.github/workflows/scan-repo.yml).

### Testing

This change was tested with commit hash https://github.com/govuk-one-login/ipv-cri-common-express/commit/36aaa2d14aef33add3ecd564323bea7f28d760a5 by doing the following:
- Disabling the 'run unit tests' action
- Removing `github.event_name != 'pull_request'` conditions from the scan-repo workflow

The workflow then ran against this PR with the same configuration as main, and with the 'collect coverage' job as the only source of coverage. The Sonar job correctly scanned the coverage and did not fail as it is currently on main.

### Issue tracking

- OJ-3681
- OJ-3675

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
