### PR TITLE
fix: Re-add Redis to lib/index.js after accidental removal in #609

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "14.0.1",
+      "version": "14.0.2",
       "license": "MIT",
       "dependencies": {
         "@govuk-one-login/frontend-ui": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -9,7 +9,7 @@ The lib folder contains a variety of Express middleware functions, designed to i
 - [`helmet`](./helmet.js) - default [Helmet](https://helmetjs.github.io/) configuration
 - [`locals`](./locals.js) - helpers for assigning [res.local](https://expressjs.com/en/api.html#res.locals) values from [req.app](https://expressjs.com/en/api.html#req.app) settings
 - [`oauth`](./oauth.js) - helpers for adding OAuth properties to the session and building the OAuth redirect url
-- [`redis`](./redis.js) - CloudFoundry configuration for Redis (deprecated)
+- [`redis`](./redis.js) - configuration for use of in-memory Redis instead of DynamoDB in local test environments
 - [`scenario-headers`](./scenario-headers.js) - helpers for setting scenario headers, used in Wiremock browser tests
 - [`settings`](./settings.js) - helpers for assigning [`req.app`](https://expressjs.com/en/api.html#req.app) values for later use with middleware
 - [`user-ip-address`](./user-ip-address.js) - function to parse out IP from semicolon delimited [X-Forwarded-For header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   axios: require("./axios"),
   oauth: require("./oauth"),
+  redis: require("./redis"),
   headers: require("./headers"),
   helmet: require("./helmet"),
   scenarioHeaders: require("./scenario-headers"),

--- a/src/lib/redis.js
+++ b/src/lib/redis.js
@@ -1,11 +1,4 @@
-/**
- * @deprecated
- * Unused CloudFoundry utility
- */
-module.exports = function getCloudFoundryRedisConfig({
-  SESSION_URL,
-  PORT,
-} = {}) {
+module.exports = function getRedisConfig({ SESSION_URL, PORT } = {}) {
   if (!SESSION_URL) {
     return {};
   }


### PR DESCRIPTION
## Proposed changes

### What changed

- Re-added Redis to `lib` barrel file - it was accidentally removed as part of Sonar work in OJ-3675 / #609
- Added information to `lib/README.md` to communicate what the file is used for these days
- Bumped common-express to v14.0.2

### Why did it change

- This logic appeared to be deprecated but is actually still in use
- Regardless, I didn't intend to remove it from the `lib/index.js` exports in #609 but accidentally did include this change from a prior version where I _had_ entirely removed `lib/redis.js`.

### Issue tracking

- BAU

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
