### PR TITLE
BAU make hmpo-components optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "14.0.3",
       "license": "MIT",
       "dependencies": {
-        "@govuk-one-login/frontend-ui": "5.0.0",
         "async": "3.2.6",
         "body-parser": "1.20.4",
         "compression": "1.8.1",
@@ -38,6 +37,7 @@
       "devDependencies": {
         "@govuk-one-login/frontend-language-toggle": "2.2.2",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
+        "@govuk-one-login/frontend-ui": "5.0.0",
         "axios": "1.16.0",
         "chai": "4.4.1",
         "chai-as-promised": "7.1.1",
@@ -67,11 +67,20 @@
       "peerDependencies": {
         "@govuk-one-login/frontend-language-toggle": "^1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "^1.0.0",
+        "@govuk-one-login/frontend-ui": "^5.0.0",
         "express": "^4.21.0",
         "govuk-frontend": "^5.0.0",
         "hmpo-components": "^8.0.5",
         "hmpo-form-wizard": ">=12.0.6",
         "nunjucks": "^3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "hmpo-components": {
+          "optional": true
+        },
+        "hmpo-form-wizard": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -417,6 +426,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.7.tgz",
       "integrity": "sha512-G78BF00pluhlxATx8Gc3/wejDPg2yf2wMQPCIV6l0uotuh0wb81Qw+j7IN+rsDNMzwvtKxFpAmjKcfxJZPXh7w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -446,6 +456,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-ui/-/frontend-ui-5.0.0.tgz",
       "integrity": "sha512-ztxstiC19zSxWv2eotwSQgw8oMe+XBPtCJ2OGrXBVaiRwBl0KzX6nmZlMLJCrtGnNJF1ywlrYty/Zn8GzkiHng==",
+      "dev": true,
       "dependencies": {
         "pino": "^10.1.0"
       },
@@ -463,6 +474,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-7.1.1.tgz",
       "integrity": "sha512-aZiW4hqCF0NT0mdgC4iEy7+xkqArUbybEXtwzT5l/pVatiSUIpSeJw3/dEFR29UoqpE3jmkHqxqr8AV4DAP6uA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1048,13 +1060,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -1068,6 +1081,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1229,6 +1243,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-from": {
@@ -1242,7 +1257,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/assertion-error": {
@@ -1947,6 +1962,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -2237,6 +2253,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -2332,6 +2349,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -2606,6 +2624,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2659,6 +2678,7 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -2745,6 +2765,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -2754,6 +2775,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fakeredis": {
@@ -2860,6 +2882,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -2878,6 +2901,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -2887,6 +2911,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-cache-dir": {
@@ -3013,6 +3038,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3038,6 +3064,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3915,6 +3942,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -4758,6 +4786,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4862,6 +4891,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4878,6 +4908,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4901,6 +4932,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -5179,7 +5211,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5367,7 +5399,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
       "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
@@ -5393,7 +5425,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5953,6 +5985,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -6187,6 +6220,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -6331,6 +6365,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6799,6 +6834,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -6823,6 +6859,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -6832,6 +6869,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
@@ -6848,6 +6886,7 @@
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -7632,7 +7671,7 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -7696,6 +7735,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "test:watch": "mocha --watch"
   },
   "dependencies": {
-    "@govuk-one-login/frontend-ui": "5.0.0",
     "async": "3.2.6",
     "body-parser": "1.20.4",
     "compression": "1.8.1",
@@ -67,6 +66,7 @@
   },
   "devDependencies": {
     "@govuk-one-login/frontend-language-toggle": "2.2.2",
+    "@govuk-one-login/frontend-ui": "5.0.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
     "axios": "1.16.0",
     "chai": "4.4.1",
@@ -95,8 +95,17 @@
     "@govuk-one-login/frontend-passthrough-headers": "^1.0.0",
     "express": "^4.21.0",
     "govuk-frontend": "^5.0.0",
-    "hmpo-components": "^8.0.5",
+    "@govuk-one-login/frontend-ui": "^5.0.0",
+    "hmpo-components": "^7.1.0 || ^8.0.5",
     "hmpo-form-wizard": ">=12.0.6",
     "nunjucks": "^3.2.4"
+  },
+  "peerDependenciesMeta": {
+    "hmpo-components": {
+      "optional": true
+    },
+    "hmpo-form-wizard": {
+      "optional": true
+    }
   }
 }

--- a/src/bootstrap/index.js
+++ b/src/bootstrap/index.js
@@ -26,7 +26,7 @@ const setup = (
       ...options.logs,
     });
 
-  if (options.redis !== false)
+  if (options.redis != null && options.redis !== false)
     redisClient.setup({
       ...config.get("redis"),
       ...options.redis,
@@ -68,7 +68,7 @@ const setup = (
       ...options.errors,
     });
 
-  if (options.port !== false)
+  if (options.port != null && options.port !== false)
     middleware.listen(app, {
       port: options.port || config.get("port"),
       host: options.host || config.get("host"),

--- a/src/bootstrap/middleware/index.js
+++ b/src/bootstrap/middleware/index.js
@@ -99,10 +99,27 @@ const middleware = {
     const cookies = require("./cookies");
     const bodyParser = require("body-parser");
     const translation = require("./translation");
-    const hmpoComponents = require("hmpo-components");
     const publicMiddleware = require("./public");
     const nunjucks = require("./nunjucks");
     const headers = require("./headers");
+
+    let hmpoComponents = null;
+    let hmpoComponentsDir = null;
+    const hmpoAffectedOptions = [];
+    try {
+      hmpoComponentsDir = path.dirname(require.resolve("hmpo-components"));
+      hmpoComponents = require("hmpo-components");
+    } catch {
+      if (views !== undefined || nunjucksOptions !== undefined) {
+        hmpoAffectedOptions.push('"views"/"nunjucks"');
+      }
+      if (locales !== undefined || translationOptions !== undefined) {
+        hmpoAffectedOptions.push('"locales"/"translation"');
+      }
+      if (publicOptions !== false) {
+        hmpoAffectedOptions.push('"public"');
+      }
+    }
 
     urls.public = urls.public || "/public";
     urls.publicImages =
@@ -139,6 +156,7 @@ const middleware = {
           publicDirs,
           publicImagesDirs,
           public: publicOptions,
+          hmpoComponentsDir,
         }),
       );
 
@@ -167,9 +185,31 @@ const middleware = {
       next();
     });
 
-    const nunjucksEnv = nunjucks.setup(app, { views, ...nunjucksOptions });
-    translation.setup(app, { locales, ...translationOptions });
-    hmpoComponents.setup(app, nunjucksEnv);
+    const nunjucksEnv = nunjucks.setup(app, {
+      views,
+      hmpoComponentsDir,
+      ...nunjucksOptions,
+    });
+
+    if (locales !== undefined || translationOptions !== undefined) {
+      translation.setup(app, {
+        locales,
+        hmpoComponentsDir,
+        ...translationOptions,
+      });
+    }
+
+    if (hmpoComponents) {
+      hmpoComponents.setup(app, nunjucksEnv);
+    }
+
+    if (hmpoAffectedOptions.length > 0) {
+      logger
+        .get(PACKAGE_NAME)
+        .info(
+          `'hmpo-components' is not installed so additional setup has not been applied for: ${hmpoAffectedOptions.join(", ")}.`,
+        );
+    }
 
     return app;
   },

--- a/src/bootstrap/middleware/nunjucks.js
+++ b/src/bootstrap/middleware/nunjucks.js
@@ -5,7 +5,10 @@ const config = require("../lib/config");
 const nunjucks = require("nunjucks");
 const frontendUi = require("@govuk-one-login/frontend-ui");
 
-const setup = (app, { views = "views", ...otherOptions } = {}) => {
+const setup = (
+  app,
+  { views = "views", hmpoComponentsDir, ...otherOptions } = {},
+) => {
   const isDevEnv = Boolean(app.get("dev"));
   const APP_ROOT = config.get("APP_ROOT");
 
@@ -13,10 +16,9 @@ const setup = (app, { views = "views", ...otherOptions } = {}) => {
 
   views = [
     ...views,
-    path.resolve(
-      path.dirname(require.resolve("hmpo-components")),
-      "components",
-    ),
+    ...(hmpoComponentsDir
+      ? [path.resolve(hmpoComponentsDir, "components")]
+      : []),
     path.resolve(path.dirname(require.resolve("govuk-frontend")), ".."),
     path.resolve("node_modules/@govuk-one-login/"),
   ];

--- a/src/bootstrap/middleware/public.js
+++ b/src/bootstrap/middleware/public.js
@@ -7,6 +7,7 @@ const middleware = ({
   publicDirs = ["public"],
   publicImagesDirs = ["assets/images"],
   public: publicOptions = { maxAge: 86400000 },
+  hmpoComponentsDir,
 } = {}) => {
   const router = express.Router();
 
@@ -24,17 +25,15 @@ const middleware = ({
     ),
   );
 
-  router.use(
-    urls.publicImages,
-    express.static(
-      path.resolve(
-        path.dirname(require.resolve("hmpo-components")),
-        "assets",
-        "images",
+  if (hmpoComponentsDir) {
+    router.use(
+      urls.publicImages,
+      express.static(
+        path.resolve(hmpoComponentsDir, "assets", "images"),
+        publicOptions,
       ),
-      publicOptions,
-    ),
-  );
+    );
+  }
 
   router.use(
     urls.public,

--- a/src/bootstrap/middleware/translation.js
+++ b/src/bootstrap/middleware/translation.js
@@ -4,13 +4,16 @@ const path = require("node:path");
 const fs = require("node:fs");
 const i18n = require("hmpo-i18n");
 
-const setup = (app, { locales = ".", ...otherOptions } = {}) => {
+const setup = (
+  app,
+  { locales = ".", hmpoComponentsDir, ...otherOptions } = {},
+) => {
   const APP_ROOT = config.get("APP_ROOT");
   const isDevEnv = Boolean(app.get("dev"));
 
   if (!Array.isArray(locales)) locales = [locales];
 
-  locales = [...locales, path.dirname(require.resolve("hmpo-components"))];
+  locales = [...locales, ...(hmpoComponentsDir ? [hmpoComponentsDir] : [])];
 
   locales = locales
     .map((dir) => path.resolve(APP_ROOT, dir))

--- a/test/bootstrap/middleware/spec.index.js
+++ b/test/bootstrap/middleware/spec.index.js
@@ -1,4 +1,6 @@
+const path = require("path");
 const proxyquire = require("proxyquire").noPreserveCache();
+const hmpoComponentsDir = path.dirname(require.resolve("hmpo-components"));
 
 describe("middleware functions", () => {
   let middleware, app;
@@ -144,6 +146,7 @@ describe("middleware functions", () => {
         publicDirs: ["public"],
         publicImagesDirs: ["assets/images"],
         public: { maxAge: 3600 },
+        hmpoComponentsDir,
       });
       app.use.should.have.been.calledWithExactly("public middleware");
     });
@@ -257,6 +260,7 @@ describe("middleware functions", () => {
         publicDirs: ["public"],
         publicImagesDirs: ["assets/images"],
         public: { maxAge: 3600 },
+        hmpoComponentsDir,
       });
       app.use.should.have.been.calledWithExactly("public middleware");
     });
@@ -307,6 +311,7 @@ describe("middleware functions", () => {
       middleware.setup({ views: "a/dir", nunjucks: { additional: "options" } });
       stubs.nunjucks.setup.should.have.been.calledWithExactly(app, {
         views: "a/dir",
+        hmpoComponentsDir,
         additional: "options",
       });
     });
@@ -318,8 +323,14 @@ describe("middleware functions", () => {
       });
       stubs.translation.setup.should.have.been.calledWithExactly(app, {
         locales: "a/dir",
+        hmpoComponentsDir,
         additional: "options",
       });
+    });
+
+    it("should not setup translation when no locales or translation options are provided", () => {
+      middleware.setup({});
+      stubs.translation.setup.should.not.have.been.called;
     });
 
     it("should setup headers", () => {

--- a/test/bootstrap/middleware/spec.nunjucks.js
+++ b/test/bootstrap/middleware/spec.nunjucks.js
@@ -28,7 +28,6 @@ describe("nunjucks middleware", () => {
     nunjucks.configure.should.have.been.calledWithExactly(
       [
         APP_ROOT + "/test/bootstrap/fixtures/views",
-        APP_ROOT + "/node_modules/hmpo-components/components",
         APP_ROOT + "/node_modules/govuk-frontend/dist",
         APP_ROOT + "/node_modules/@govuk-one-login",
       ],
@@ -41,12 +40,25 @@ describe("nunjucks middleware", () => {
     );
   });
 
+  it("should configure nunjucks with hmpo-components views when hmpoComponentsDir is provided", () => {
+    const hmpoComponentsDir = APP_ROOT + "/node_modules/hmpo-components";
+    setupNunjucks(app, { hmpoComponentsDir });
+    nunjucks.configure.should.have.been.calledWithExactly(
+      [
+        APP_ROOT + "/test/bootstrap/fixtures/views",
+        APP_ROOT + "/node_modules/hmpo-components/components",
+        APP_ROOT + "/node_modules/govuk-frontend/dist",
+        APP_ROOT + "/node_modules/@govuk-one-login",
+      ],
+      sinon.match.object,
+    );
+  });
+
   it("should filter out a view if not present", () => {
     setupNunjucks(app, { views: ["views", "not_found"] });
     nunjucks.configure.should.have.been.calledWithExactly(
       [
         APP_ROOT + "/test/bootstrap/fixtures/views",
-        APP_ROOT + "/node_modules/hmpo-components/components",
         APP_ROOT + "/node_modules/govuk-frontend/dist",
         APP_ROOT + "/node_modules/@govuk-one-login",
       ],

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -29,8 +29,8 @@ describe("Public static assets", () => {
     it("adds default public directories", () => {
       const router = publicMiddleware();
 
-      express.static.should.have.callCount(4);
-      router.use.should.have.callCount(4);
+      express.static.should.have.callCount(3);
+      router.use.should.have.callCount(3);
 
       router.use
         .getCall(0)
@@ -57,6 +57,27 @@ describe("Public static assets", () => {
 
       router.use
         .getCall(2)
+        .should.have.been.calledWithExactly("/public", "static middleware");
+      express.static
+        .getCall(2)
+        .should.have.been.calledWithExactly(
+          APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
+          { maxAge: 86400000 },
+        );
+    });
+
+    it("adds hmpo-components assets when hmpoComponentsDir is provided", () => {
+      const path = require("path");
+      const hmpoComponentsDir = path.dirname(
+        require.resolve("hmpo-components"),
+      );
+      publicMiddleware({ hmpoComponentsDir });
+
+      express.static.should.have.callCount(4);
+      router.use.should.have.callCount(4);
+
+      router.use
+        .getCall(2)
         .should.have.been.calledWithExactly(
           "/public/images",
           "static middleware",
@@ -64,17 +85,7 @@ describe("Public static assets", () => {
       express.static
         .getCall(2)
         .should.have.been.calledWithExactly(
-          APP_ROOT + "/node_modules/hmpo-components/assets/images",
-          { maxAge: 86400000 },
-        );
-
-      router.use
-        .getCall(3)
-        .should.have.been.calledWithExactly("/public", "static middleware");
-      express.static
-        .getCall(3)
-        .should.have.been.calledWithExactly(
-          APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
+          hmpoComponentsDir + "/assets/images",
           { maxAge: 86400000 },
         );
     });

--- a/test/bootstrap/middleware/spec.translation.js
+++ b/test/bootstrap/middleware/spec.translation.js
@@ -20,6 +20,20 @@ describe("translation middleware", () => {
   it("should use the i18n middleware specifying the app root as the baseDir", () => {
     translation.setup(app);
     i18n.middleware.should.have.been.calledWithExactly(app, {
+      baseDir: [APP_ROOT + "/test/bootstrap/fixtures"],
+      noCache: true,
+      watch: true,
+      allowedLangs: ["en", "cy"],
+      cookie: { name: "lang" },
+      query: "lang",
+    });
+  });
+
+  it("should include hmpo-components locales when hmpoComponentsDir is provided", () => {
+    translation.setup(app, {
+      hmpoComponentsDir: APP_ROOT + "/node_modules/hmpo-components",
+    });
+    i18n.middleware.should.have.been.calledWithExactly(app, {
       baseDir: [
         APP_ROOT + "/test/bootstrap/fixtures",
         APP_ROOT + "/node_modules/hmpo-components",
@@ -35,10 +49,7 @@ describe("translation middleware", () => {
   it("should use the i18n middleware specifying a custom locales locations", () => {
     translation.setup(app, { locales: [".", "./dir_not_found"] });
     i18n.middleware.should.have.been.calledWithExactly(app, {
-      baseDir: [
-        APP_ROOT + "/test/bootstrap/fixtures",
-        APP_ROOT + "/node_modules/hmpo-components",
-      ],
+      baseDir: [APP_ROOT + "/test/bootstrap/fixtures"],
       noCache: true,
       watch: true,
       allowedLangs: ["en", "cy"],


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- make hmpo-components and frontend-ui peer deps, guard optional setup calls for redis, port and translation
- this change should not impact any existing hmpo components based cri fronts

### Why did it change

- we want to move away from HMPO components where possible, begin by making them optional in common-express

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

### screens

example log line when `hmpo-components` is not present
<img width="1364" height="111" alt="image" src="https://github.com/user-attachments/assets/ca5cca44-1c18-48b4-bc85-aedfbbd55056" />

