### PR TITLE
BAU add additionalNamespaces and onInit to i18next

### DIFF
--- a/src/lib/i18next/configure.js
+++ b/src/lib/i18next/configure.js
@@ -1,8 +1,14 @@
 const defaultConfig = require("./default-config");
 
-const configure = function ({ cookieDomain, debug = false, secure } = {}) {
+const configure = function ({
+  cookieDomain,
+  debug = false,
+  secure,
+  additionalNamespaces = [],
+} = {}) {
   return {
     ...defaultConfig,
+    ns: [...defaultConfig.ns, ...additionalNamespaces],
     debug: debug,
     detection: {
       ...defaultConfig.detection,

--- a/src/lib/i18next/configure.test.js
+++ b/src/lib/i18next/configure.test.js
@@ -18,7 +18,7 @@ describe("configure", () => {
         debug: true,
       });
 
-      expect(defaultConfig).to.include(configWithoutDetection);
+      expect(defaultConfig).to.deep.include(configWithoutDetection);
 
       expect(debug).to.be.true;
 
@@ -27,6 +27,18 @@ describe("configure", () => {
         cookieSecure: true,
         cookieDomain: "localhost",
       });
+    });
+
+    it("should merge additionalNamespaces into ns", () => {
+      const config = configure({ additionalNamespaces: ["frontend-ui"] });
+
+      expect(config.ns).to.deep.equal([...defaultConfig.ns, "frontend-ui"]);
+    });
+
+    it("should not modify ns when additionalNamespaces is empty", () => {
+      const config = configure({ additionalNamespaces: [] });
+
+      expect(config.ns).to.deep.equal(defaultConfig.ns);
     });
   });
 });

--- a/src/lib/i18next/handler.js
+++ b/src/lib/i18next/handler.js
@@ -4,11 +4,19 @@ const i18nextMiddleware = require("i18next-http-middleware");
 
 const { configure } = require("./configure");
 
-const handler = ({ cookieDomain, debug, secure } = {}) => {
+const handler = ({
+  cookieDomain,
+  debug,
+  secure,
+  additionalNamespaces,
+  onInit,
+} = {}) => {
   i18next
     .use(Backend)
     .use(i18nextMiddleware.LanguageDetector)
-    .init(configure({ cookieDomain, debug, secure }));
+    .init(configure({ cookieDomain, debug, secure, additionalNamespaces }));
+
+  onInit?.(i18next);
 
   return i18nextMiddleware.handle(i18next, {
     ignoreRoutes: ["/public"], // or function(req, res, options, i18next) { /* return true to ignore */ }

--- a/src/lib/i18next/handler.test.js
+++ b/src/lib/i18next/handler.test.js
@@ -76,7 +76,28 @@ describe("handler", () => {
       debug: true,
       secure: true,
       cookieDomain: "subdomain.local",
+      additionalNamespaces: undefined,
     });
+  });
+
+  it("should thread additionalNamespaces through to configure", () => {
+    handler.handler({ additionalNamespaces: ["frontend-ui"] });
+
+    expect(configure.configure).to.have.been.calledWithExactly(
+      sinon.match({ additionalNamespaces: ["frontend-ui"] }),
+    );
+  });
+
+  it("should call onInit with i18next after init", () => {
+    const onInit = sinon.stub();
+    handler.handler({ onInit });
+
+    expect(onInit).to.have.been.calledWithExactly(i18next);
+    expect(onInit).to.have.been.calledAfter(i18next.init);
+  });
+
+  it("should not require onInit to be provided", () => {
+    expect(() => handler.handler()).to.not.throw();
   });
   it("should call init with result from configure", () => {
     handler.handler({

--- a/src/lib/i18next/index.js
+++ b/src/lib/i18next/index.js
@@ -1,11 +1,19 @@
+const i18next = require("i18next");
 const { handler } = require("./handler");
 const { replaceTranslate } = require("./replace-translate");
 
-const setI18n = ({ router, config: { cookieDomain, debug, secure } }) => {
-  router.use(handler({ cookieDomain, debug, secure }));
+const setI18n = ({
+  router,
+  config: { cookieDomain, debug, secure, additionalNamespaces },
+  onInit,
+}) => {
+  router.use(
+    handler({ cookieDomain, debug, secure, additionalNamespaces, onInit }),
+  );
   router.use(replaceTranslate);
 };
 
 module.exports = {
-  setI18n: setI18n,
+  setI18n,
+  i18next,
 };

--- a/src/lib/i18next/index.test.js
+++ b/src/lib/i18next/index.test.js
@@ -2,7 +2,7 @@ const proxyquire = require("proxyquire");
 const handler = sinon.stub().returns("handler function");
 const replaceTranslate = sinon.stub();
 
-const { setI18n } = proxyquire("./", {
+const { setI18n, i18next } = proxyquire("./", {
   "./handler": {
     handler,
   },
@@ -28,11 +28,41 @@ describe("i18next", () => {
     expect(handlerCall).to.have.been.calledWithExactly("handler function");
   });
   it("should call handler", () => {
-    expect(handler).to.have.been.calledWithExactly(config);
+    expect(handler).to.have.been.calledWithExactly({
+      debug: true,
+      secure: false,
+      cookieDomain: "sub.domain.local",
+      additionalNamespaces: undefined,
+      onInit: undefined,
+    });
   });
   it("should use replaceTranslate", () => {
     const replaceCall = router.use.getCall(1);
 
     expect(replaceCall).to.have.been.calledWithExactly(replaceTranslate);
+  });
+
+  it("should pass additionalNamespaces through to handler", () => {
+    handler.resetHistory();
+    setI18n({
+      router,
+      config: { ...config, additionalNamespaces: ["frontend-ui"] },
+    });
+
+    expect(handler).to.have.been.calledWithExactly(
+      sinon.match({ additionalNamespaces: ["frontend-ui"] }),
+    );
+  });
+
+  it("should pass onInit through to handler", () => {
+    handler.resetHistory();
+    const onInit = sinon.stub();
+    setI18n({ router, config, onInit });
+
+    expect(handler).to.have.been.calledWithExactly(sinon.match({ onInit }));
+  });
+
+  it("should export the i18next singleton", () => {
+    expect(i18next).to.equal(require("i18next"));
   });
 });

--- a/src/lib/i18next/replace-translate.js
+++ b/src/lib/i18next/replace-translate.js
@@ -1,5 +1,7 @@
 const replaceTranslate = (req, res, next) => {
-  req.translate = req.i18n.getFixedT(req.i18n.language);
+  const t = req.i18n.getFixedT(req.i18n.language);
+  req.translate = t;
+  res.locals.translate = (key, opts) => t(key, { ...res.locals, ...opts });
   next();
 };
 

--- a/src/lib/i18next/replace-translate.test.js
+++ b/src/lib/i18next/replace-translate.test.js
@@ -35,6 +35,40 @@ describe("replaceTranslate", () => {
     expect(req.translate).to.equal(translate);
   });
 
+  it("should set res.locals.translate as a function", () => {
+    replaceTranslate(req, res, next);
+
+    expect(res.locals.translate).to.be.a("function");
+  });
+
+  it("should call translate with res.locals spread as interpolation context", () => {
+    const translate = sinon.stub();
+    req.i18n.getFixedT.returns(translate);
+    res.locals.favFood = "Sausage";
+
+    replaceTranslate(req, res, next);
+    res.locals.translate("some.key");
+
+    expect(translate).to.have.been.calledWithExactly(
+      "some.key",
+      sinon.match({ favFood: "Sausage" }),
+    );
+  });
+
+  it("should allow opts to override res.locals in interpolation context", () => {
+    const translate = sinon.stub();
+    req.i18n.getFixedT.returns(translate);
+    res.locals.favFood = "Sausage";
+
+    replaceTranslate(req, res, next);
+    res.locals.translate("some.key", { favFood: "Saucisson" });
+
+    expect(translate).to.have.been.calledWithExactly(
+      "some.key",
+      sinon.match({ favFood: "Saucisson" }),
+    );
+  });
+
   it("should call next", () => {
     replaceTranslate(req, res, next);
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- add additionalNamespaces and onInit to i18next
- export singleton
- set res.locals.translate

### Why did it change

- adding support for frontend-ui `setFrontendUiTranslations` 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
