### PR TITLE
BAU fix session save race condition on redirect

### DIFF
--- a/src/bootstrap/middleware/error-handler.js
+++ b/src/bootstrap/middleware/error-handler.js
@@ -43,6 +43,16 @@ const middleware =
         req.method === "POST" ||
         req.path.replace(/\/+$/, "") !== err.redirect
       ) {
+        if (req.session?.save) {
+          return req.session.save((saveErr) => {
+            if (saveErr) {
+              logger.logError(req, saveErr, {
+                messagePrefix: "Error saving session before redirect",
+              });
+            }
+            res.redirect(err.redirect);
+          });
+        }
         return res.redirect(err.redirect);
       }
     }

--- a/src/bootstrap/middleware/index.js
+++ b/src/bootstrap/middleware/index.js
@@ -237,7 +237,7 @@ const middleware = {
     { port = 3000, host = "0.0.0.0" } = {},
   ) {
     app.listen(port, host, () => {
-      logger.get().info("Listening on http://:listen", {
+      logger.get(PACKAGE_NAME).info("Listening on http://:listen", {
         bind: host,
         port,
         listen: (host === "0.0.0.0" ? "localhost" : host) + ":" + port,

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -54,7 +54,19 @@ module.exports = {
 
       logger.info("Redirecting to callback with error", error);
 
-      return res.redirect(redirectUrl.toString());
+      if (req.session?.save) {
+        req.session.save((err) => {
+          if (err) {
+            logger.error(
+              { error: err.message },
+              "Error saving session before redirect to callback with error",
+            );
+          }
+          res.redirect(redirectUrl.toString());
+        });
+      } else {
+        res.redirect(redirectUrl.toString());
+      }
     } catch {
       return next(err);
     }

--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -128,7 +128,19 @@ module.exports = {
 
       logger.info("Redirecting to callback");
 
-      return res.redirect(redirectUrl.toString());
+      if (req.session?.save) {
+        req.session.save((err) => {
+          if (err) {
+            logger.error(
+              { error: err.message },
+              "Error saving session before redirect to callback",
+            );
+          }
+          res.redirect(redirectUrl.toString());
+        });
+      } else {
+        res.redirect(redirectUrl.toString());
+      }
     } catch (e) {
       return next(e);
     }
@@ -140,6 +152,18 @@ module.exports = {
       return next(new Error("Missing APP.PATHS.ENTRYPOINT value"));
     }
 
-    res.redirect(entryPointPath);
+    if (req.session?.save) {
+      req.session.save((err) => {
+        if (err) {
+          logger.error(
+            { error: err.message },
+            "Error saving session before redirect to entry point",
+          );
+        }
+        res.redirect(entryPointPath);
+      });
+    } else {
+      res.redirect(entryPointPath);
+    }
   },
 };

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -15,6 +15,10 @@ describe("oauth middleware", () => {
     next = setup.next;
   });
 
+  afterEach(() => {
+    require("../../bootstrap/lib/logger").get().error.resetHistory();
+  });
+
   describe("addAuthParamsToSession", () => {
     beforeEach(() => {
       req = {
@@ -401,6 +405,26 @@ describe("oauth middleware", () => {
           .and(sinon.match.has("code", "ERR_INVALID_URL")),
       );
     });
+
+    context("with session.save available", () => {
+      beforeEach(() => {
+        req.session.save = sinon.stub().yields(null);
+      });
+
+      it("should save the session before redirecting", async () => {
+        await middleware.redirectToCallback(req, res, next);
+
+        expect(req.session.save).to.have.been.calledBefore(res.redirect);
+      });
+
+      it("should still redirect if session save fails", async () => {
+        req.session.save = sinon.stub().yields(new Error("save failed"));
+
+        await middleware.redirectToCallback(req, res, next);
+
+        expect(res.redirect).to.have.been.called;
+      });
+    });
   });
 
   describe("redirectToAddress", () => {
@@ -417,6 +441,27 @@ describe("oauth middleware", () => {
       await middleware.redirectToEntryPoint(req, res, next);
 
       expect(res.redirect).to.have.been.calledWith("/app/entry");
+    });
+
+    context("with session.save available", () => {
+      beforeEach(() => {
+        req.app.get.withArgs("APP.PATHS.ENTRYPOINT").returns("/app/entry");
+        req.session.save = sinon.stub().yields(null);
+      });
+
+      it("should save the session before redirecting", async () => {
+        await middleware.redirectToEntryPoint(req, res, next);
+
+        expect(req.session.save).to.have.been.calledBefore(res.redirect);
+      });
+
+      it("should still redirect if session save fails", async () => {
+        req.session.save = sinon.stub().yields(new Error("save failed"));
+
+        await middleware.redirectToEntryPoint(req, res, next);
+
+        expect(res.redirect).to.have.been.called;
+      });
     });
 
     context("with missing APP.PATHS.ENTRYPOINT", () => {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- express-session with async stores (e.g. DynamoDB) does not guarantee the session is fully flushed before the client follows the redirect and fires a new request

### Why did it change

- race condition bugs are present in the CRIs consuming the oauth2 middleware

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
