### PR TITLE
OJ-3677: Address logging gaps in Pino

### DIFF
--- a/src/bootstrap/lib/logger.js
+++ b/src/bootstrap/lib/logger.js
@@ -27,7 +27,7 @@ const redactQueryParams = (url) => {
 
 const getErrorProperties = (err) => {
   const properties = {};
-  for (const key in err) {
+  for (const key of Object.keys(err)) {
     const value = err[key];
     if (
       typeof value === "string" ||

--- a/src/bootstrap/lib/logger.js
+++ b/src/bootstrap/lib/logger.js
@@ -25,6 +25,45 @@ const redactQueryParams = (url) => {
   return url;
 };
 
+const getErrorProperties = (err) => {
+  const properties = {};
+  for (const key in err) {
+    const value = err[key];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      properties[key] = value;
+    }
+  }
+  return properties;
+};
+
+const splitStack = (stack) =>
+  typeof stack === "string" ? stack.split(/[\n\r]+/) : undefined;
+
+const serializeError = (err) => {
+  const serialized = {
+    ...getErrorProperties(err),
+    type: err.name,
+    message: err.message,
+    stack: err.stack,
+  };
+  if (err.original) {
+    serialized.original =
+      err.original instanceof Error
+        ? {
+            ...getErrorProperties(err.original),
+            type: err.original.name,
+            message: err.original.message,
+            stack: err.original.stack,
+          }
+        : err.original;
+  }
+  return serialized;
+};
+
 const setup = (options = config.get("logs", {})) => hmpoLogger.config(options);
 
 const get = (name = ":hmpo-app", level = 1) => {
@@ -48,6 +87,14 @@ const get = (name = ":hmpo-app", level = 1) => {
         return {
           method: req.method,
           url: redactQueryParams(req.url),
+          clientip: req.ip ?? req.connection?.remoteAddress,
+          remoteAddress: req.connection?.remoteAddress,
+          hostname: req.hostname,
+          httpversion:
+            req.httpVersionMajor && req.httpVersionMinor
+              ? `${req.httpVersionMajor}.${req.httpVersionMinor}`
+              : undefined,
+          uniqueID: req.headers?.["x-uniq-id"],
         };
       },
       res: (res) => {
@@ -55,15 +102,10 @@ const get = (name = ":hmpo-app", level = 1) => {
           statusCode: res.statusCode,
           sessionId: res.locals.sessionId,
           location: redactQueryParams(res.getHeader("location")),
+          bytes: res.getHeader("content-length"),
         };
       },
-      err: (err) => {
-        return {
-          type: err.name,
-          message: err.message,
-          stack: err.stack,
-        };
-      },
+      err: serializeError,
     },
   });
   pinoLoggers.set(name, newPinoLogger);
@@ -79,7 +121,16 @@ function logError(req, err, options = {}) {
       : err.message;
 
     logger.error({
-      ...(err.code && { code: err.code }),
+      ...getErrorProperties(err),
+      stack: splitStack(err.stack),
+      ...(err.original && {
+        original:
+          err.original instanceof Error
+            ? serializeError(err.original)
+            : err.original,
+      }),
+      clientip: req.ip ?? req.connection?.remoteAddress,
+      sessionID: req.sessionID,
       method: req.method,
       request: redactQueryParams(req.originalUrl || req.url),
       message,

--- a/test/bootstrap/lib/spec.logger.js
+++ b/test/bootstrap/lib/spec.logger.js
@@ -117,6 +117,82 @@ describe("Logger", () => {
       const logger2 = logger.get("cached-logger");
       expect(logger1).to.equal(logger2);
     });
+
+    describe("serializers", () => {
+      const pino = require("pino");
+
+      const getSerializers = () =>
+        logger.get("serializer-test")[pino.symbols.serializersSym];
+
+      it("serializes error properties for hmpo-logger parity", () => {
+        const err = new Error("Something failed");
+        err.code = "FAIL";
+        err.status = 403;
+
+        const serialized = getSerializers().err(err);
+
+        expect(serialized.type).to.equal("Error");
+        expect(serialized.message).to.equal("Something failed");
+        expect(serialized.stack).to.be.a("string");
+        expect(serialized.code).to.equal("FAIL");
+        expect(serialized.status).to.equal(403);
+      });
+
+      it("serializes the original error when present", () => {
+        const original = new Error("Root cause");
+        original.code = "ROOT";
+        const err = new Error("Something failed");
+        err.original = original;
+
+        const serialized = getSerializers().err(err);
+
+        expect(serialized.original.message).to.equal("Root cause");
+        expect(serialized.original.code).to.equal("ROOT");
+        expect(serialized.original.stack).to.be.a("string");
+      });
+
+      it("serializes request meta for hmpo-logger parity", () => {
+        const serialized = getSerializers().req({
+          method: "GET",
+          url: "/test?code=secret",
+          ip: "127.0.0.1",
+          connection: { remoteAddress: "10.0.0.1" },
+          hostname: "example.com",
+          httpVersionMajor: 1,
+          httpVersionMinor: 1,
+          headers: { "x-uniq-id": "uniq-123" },
+        });
+
+        expect(serialized).to.deep.equal({
+          method: "GET",
+          url: "/test?code=hidden",
+          clientip: "127.0.0.1",
+          remoteAddress: "10.0.0.1",
+          hostname: "example.com",
+          httpversion: "1.1",
+          uniqueID: "uniq-123",
+        });
+      });
+
+      it("serializes response meta for hmpo-logger parity", () => {
+        const headers = {
+          location: "/done?code=secret",
+          "content-length": 1234,
+        };
+        const serialized = getSerializers().res({
+          statusCode: 302,
+          locals: { sessionId: "session-1" },
+          getHeader: (name) => headers[name],
+        });
+
+        expect(serialized).to.deep.equal({
+          statusCode: 302,
+          sessionId: "session-1",
+          location: "/done?code=hidden",
+          bytes: 1234,
+        });
+      });
+    });
   });
 
   describe("logError", () => {
@@ -177,6 +253,51 @@ describe("Logger", () => {
       const arg = mockLogger.error.firstCall.args[0];
 
       expect(arg.message.startsWith("Added Start:")).to.equal(true);
+    });
+
+    it("should include error properties such as status at top level", function () {
+      const err = mockErr();
+      err.status = 403;
+
+      logger.logError(mockReq, err, { logger: mockLogger });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.status).to.equal(403);
+      expect(arg.code).to.equal("FAIL");
+    });
+
+    it("should include the stack as an array of lines at top level", function () {
+      const err = mockErr();
+      err.stack = "line one\nline two";
+
+      logger.logError(mockReq, err, { logger: mockLogger });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.stack).to.deep.equal(["line one", "line two"]);
+    });
+
+    it("should include the original error at top level", function () {
+      const err = mockErr();
+      err.original = new Error("Root cause");
+
+      logger.logError(mockReq, err, { logger: mockLogger });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.original.message).to.equal("Root cause");
+    });
+
+    it("should include clientip and sessionID", function () {
+      logger.logError({ ...mockReq, sessionID: "session-1" }, mockErr(), {
+        logger: mockLogger,
+      });
+
+      const arg = mockLogger.error.firstCall.args[0];
+
+      expect(arg.clientip).to.equal("127.0.0.1");
+      expect(arg.sessionID).to.equal("session-1");
     });
 
     it("should omit code if not present", function () {


### PR DESCRIPTION
## Proposed changes

### What changed and Why

Logger has been updated so that when using the Pino logger, it has parity with what the hmpo-logger outputs.
This is to fix the gaps in logging when using Pino.

Key point is that hmpo-logger flattens errors into the log entry and copies properties of an error to the top level.

Not changed was `responseTime` as it looked deliberately renamed `timeTaken` in the pino-http config. Looks intentional so I have left it as is. 

Tested using: 
```
NODE_ENV=development \
  API_BASE_URL=http://127.0.0.1:8080/ \
  USE_PINO_LOGGER=false \
  PORT=5010 \
  node src/app.js
```
(update USE_PINO_LOGGER to get before/after)

Then: 
`curl -s -o /dev/null "http://localhost:5010/nonexistent?code=secret123&safe=1"`
`curl -s -o /dev/null "http://localhost:5010/address"`

### Issue tracking
- [OJ-3677](https://govukverify.atlassian.net/browse/OJ-3677)


[OJ-3677]: https://govukverify.atlassian.net/browse/OJ-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ