### PR TITLE
fix: preserve existing translate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "15.0.1",
+      "version": "15.0.2",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/lib/i18next/replace-translate.js
+++ b/src/lib/i18next/replace-translate.js
@@ -1,7 +1,9 @@
 const replaceTranslate = (req, res, next) => {
   const t = req.i18n.getFixedT(req.i18n.language);
   req.translate = t;
-  res.locals.translate = (key, opts) => t(key, { ...res.locals, ...opts });
+  if (typeof res.locals.translate !== "function") {
+    res.locals.translate = (key, opts) => t(key, { ...res.locals, ...opts });
+  }
   next();
 };
 


### PR DESCRIPTION
## Proposed changes

### What changed
`replaceTranslate` now only assigns `res.locals.translate` when one is not already present.

### Why did it change

v15.0.0 added res.locals.translate to replaceTranslate. Because setI18n registers it as a router-level middleware, it runs after app-level middleware, so for consumers that use hmpo-components, it overwrites the `res.locals.translate` that hmpo-components installs at app level.

### Issue tracking

- OJ-3677
