### PR TITLE
fix: stop replaceTranslate overwriting an existing res.locals.translate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "15.0.1",
+      "version": "15.0.2",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/lib/i18next/replace-translate.js
+++ b/src/lib/i18next/replace-translate.js
@@ -1,7 +1,23 @@
+const { PACKAGE_NAME } = require("../constants");
+const logger = require("../../bootstrap/lib/logger");
+
+let divergenceWarningLogged = false;
+
 const replaceTranslate = (req, res, next) => {
   const t = req.i18n.getFixedT(req.i18n.language);
   req.translate = t;
-  res.locals.translate = (key, opts) => t(key, { ...res.locals, ...opts });
+  // don't overwrite an existing res.locals.translate (e.g. hmpo-components' locals
+  // middleware wraps t with recursiveRender for nunjucks placeholders in values).
+  if (typeof res.locals.translate !== "function") {
+    res.locals.translate = (key, opts) => t(key, { ...res.locals, ...opts });
+  } else if (!divergenceWarningLogged) {
+    divergenceWarningLogged = true;
+    logger
+      .get(PACKAGE_NAME)
+      .warn(
+        "existing function already present on 'res.locals.translate'. 'req.translate' is i18next getFixedT, 'res.locals.translate' is whatever an earlier middleware installed (probably hmpo-components recursiveRender wrapper)",
+      );
+  }
   next();
 };
 

--- a/src/lib/i18next/replace-translate.test.js
+++ b/src/lib/i18next/replace-translate.test.js
@@ -1,9 +1,11 @@
-const { replaceTranslate } = require("./replace-translate");
+const proxyquire = require("proxyquire");
 
 describe("replaceTranslate", () => {
   let req;
   let res;
   let next;
+  let warn;
+  let replaceTranslate;
 
   beforeEach(() => {
     const setup = setupDefaultMocks();
@@ -17,6 +19,13 @@ describe("replaceTranslate", () => {
       getFixedT: sinon.stub(),
       language: "en",
     };
+
+    warn = sinon.stub();
+    ({ replaceTranslate } = proxyquire("./replace-translate", {
+      "../../bootstrap/lib/logger": {
+        get: sinon.stub().returns({ warn }),
+      },
+    }));
   });
 
   it("should call getFixedT with language", () => {
@@ -67,6 +76,39 @@ describe("replaceTranslate", () => {
       "some.key",
       sinon.match({ favFood: "Saucisson" }),
     );
+  });
+
+  it("should not overwrite an existing res.locals.translate", () => {
+    const existing = sinon.fake();
+    res.locals.translate = existing;
+
+    replaceTranslate(req, res, next);
+
+    expect(res.locals.translate).to.equal(existing);
+  });
+
+  it("should warn when res.locals.translate is already set", () => {
+    res.locals.translate = sinon.fake();
+
+    replaceTranslate(req, res, next);
+
+    expect(warn).to.have.been.calledOnce;
+  });
+
+  it("should only warn once across multiple requests", () => {
+    res.locals.translate = sinon.fake();
+
+    replaceTranslate(req, res, next);
+    replaceTranslate(req, res, next);
+    replaceTranslate(req, res, next);
+
+    expect(warn).to.have.been.calledOnce;
+  });
+
+  it("should not warn when res.locals.translate is unset", () => {
+    replaceTranslate(req, res, next);
+
+    expect(warn).to.not.have.been.called;
   });
 
   it("should call next", () => {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- restores pre-v15 behaviour by guarding replaceTranslate against overwriting an existing `res.locals.translate` (for ex. hmpo-components), warn once to surface divergence to consumers (divergence already present pre v15, just not surfaced)

### Why did it change

- v15 made some modifications to the i18n middleware that unintentionally overwrote the locals translate function when `hmpo-components` is present

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed
