### PR TITLE
feat: sync token pattern csrf protection middleware

### DIFF
--- a/src/bootstrap/index.js
+++ b/src/bootstrap/index.js
@@ -54,6 +54,11 @@ const setup = (
       ...options.session,
     });
 
+  if (options.csrf) {
+    const csrf = require("../lib/csrf");
+    app.use(csrf(options.csrf));
+  }
+
   const router = express.Router();
   router.use(protect);
   app.use(router);

--- a/src/lib/csrf/README.md
+++ b/src/lib/csrf/README.md
@@ -1,0 +1,58 @@
+# CSRF middleware
+
+Synchronizer Token Pattern CSRF protection for Express apps using `express-session`.
+
+Do not use this if your application uses `hmpo-form-wizard` (it provides its own CSRF implementation).
+
+## Setup
+
+Pass a `csrf` option to `bootstrap.setup`. It mounts _after_ session middleware.
+
+```js
+commonExpress.bootstrap.setup({
+  csrf: { secret: appConfig.CSRF_SECRET },
+  // ...
+});
+```
+
+`secret` is a non-empty string provided by the CRI front (e.g. from env).
+
+## Templates
+
+The current token is available on `res.locals.csrfToken`. Render it as a hidden field in any form that uses an unsafe request (see behaviour):
+
+```njk
+<form method="post" action="/submit">
+  <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+  {# ...fields... #}
+</form>
+```
+
+## Behaviour
+
+- `GET` / `HEAD` / `OPTIONS`: generates a token, sets `res.locals.csrfToken`.
+- `POST` / `PUT` / `PATCH` / `DELETE`: requires a valid token in `req.body._csrf` or the `x-csrf-token` header (priority: body -> header).
+- On error: `next(err)` with a `CsrfError` (`status: 403`, `code: 'BAD_CSRF_TOKEN'`).
+
+## Rotating the secret
+
+`secret` accepts an array. Tokens are signed with the first entry and verified against any entry. This pattern allows any consumer to roll out a new secret across replicas without rejecting tokens that were created before the rollout completed.
+
+Two deploys are required for a successful rotation:
+
+1. Open the window
+   - Deploy with `secret: [newSecret, oldSecret]`. Wait for all old tasks to fully drain. During this window every task signs with `newSecret` and tokens created by replicas still on `oldSecret` continue to work.
+2. Close the window
+   - Deploy with `secret: newSecret`. Old tokens are now rejected.
+
+## Client-side fetch
+
+Read the token from the rendered page and send it as a header:
+
+```js
+fetch("/api/thing", {
+  method: "POST",
+  headers: { "x-csrf-token": csrfToken },
+  body: JSON.stringify(payload),
+});
+```

--- a/src/lib/csrf/error.js
+++ b/src/lib/csrf/error.js
@@ -1,0 +1,10 @@
+class CsrfError extends Error {
+  constructor(message = "Invalid CSRF token") {
+    super(message);
+    this.name = "CsrfError";
+    this.code = "BAD_CSRF_TOKEN";
+    this.status = 403;
+  }
+}
+
+module.exports = CsrfError;

--- a/src/lib/csrf/index.js
+++ b/src/lib/csrf/index.js
@@ -1,0 +1,7 @@
+const middleware = require("./middleware");
+const CsrfError = require("./error");
+const token = require("./token");
+
+module.exports = middleware;
+module.exports.CsrfError = CsrfError;
+module.exports.token = token;

--- a/src/lib/csrf/middleware.js
+++ b/src/lib/csrf/middleware.js
@@ -1,0 +1,51 @@
+const token = require("./token");
+const CsrfError = require("./error");
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const TOKEN_FIELD = "_csrf";
+const TOKEN_HEADER = "x-csrf-token";
+
+const extractToken = (req) =>
+  req.body?.[TOKEN_FIELD] ?? req.headers?.[TOKEN_HEADER];
+
+const normaliseSecrets = (secret) => {
+  const candidates = Array.isArray(secret) ? secret : [secret];
+  if (candidates.length === 0) {
+    throw new Error("csrf middleware requires a non-empty 'secret' option");
+  }
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string" || candidate.length === 0) {
+      throw new Error("csrf middleware requires a non-empty 'secret' option");
+    }
+  }
+  return candidates;
+};
+
+const csrf = ({ secret } = {}) => {
+  const secrets = normaliseSecrets(secret);
+
+  return function csrfMiddleware(req, res, next) {
+    if (!req.session) {
+      return next(new CsrfError("CSRF middleware requires a session"));
+    }
+
+    if (!req.session.csrfSecret) {
+      req.session.csrfSecret = token.setSessionSecret();
+    }
+
+    res.locals.csrfToken = token.create(secrets, req.session.csrfSecret);
+
+    if (SAFE_METHODS.has(req.method)) {
+      return next();
+    }
+
+    const submitted = extractToken(req);
+    if (!token.verify(secrets, req.session.csrfSecret, submitted)) {
+      return next(new CsrfError());
+    }
+
+    return next();
+  };
+};
+
+module.exports = csrf;

--- a/src/lib/csrf/middleware.test.js
+++ b/src/lib/csrf/middleware.test.js
@@ -1,0 +1,231 @@
+const csrf = require("./middleware");
+const CsrfError = require("./error");
+const token = require("./token");
+
+const SECRET = "hunter2"; // pragma: allowlist secret
+const SESSION_CSRF_SECRET = "top-secret"; // pragma: allowlist secret
+
+const buildReq = (overrides = {}) => ({
+  method: "GET",
+  session: { csrfSecret: SESSION_CSRF_SECRET },
+  body: {},
+  headers: {},
+  ...overrides,
+});
+
+const buildRes = () => ({ locals: {} });
+
+describe("lib/csrf/middleware", () => {
+  let next;
+
+  beforeEach(() => {
+    next = sinon.fake();
+  });
+
+  describe("configuration", () => {
+    it("throws when no secret is provided", () => {
+      expect(() => csrf()).to.throw(/secret/);
+      expect(() => csrf({})).to.throw(/secret/);
+      expect(() => csrf({ secret: "" })).to.throw(/secret/);
+      expect(() => csrf({ secret: 123 })).to.throw(/secret/);
+    });
+
+    it("throws when secret is an empty array", () => {
+      expect(() => csrf({ secret: [] })).to.throw(/secret/);
+    });
+
+    it("throws when secret array contains invalid entries", () => {
+      expect(() => csrf({ secret: ["valid", ""] })).to.throw(/secret/);
+      expect(() => csrf({ secret: ["valid", 42] })).to.throw(/secret/);
+    });
+
+    it("returns middleware when given a secret string", () => {
+      expect(csrf({ secret: SECRET })).to.be.a("function");
+    });
+
+    it("returns middleware when given a secret array", () => {
+      expect(csrf({ secret: [SECRET, "previous"] })).to.be.a("function");
+    });
+  });
+
+  describe("session requirement", () => {
+    it("calls next with CsrfError when no session exists", () => {
+      const req = buildReq();
+      delete req.session;
+
+      csrf({ secret: SECRET })(req, buildRes(), next);
+
+      expect(next).to.have.been.calledOnce;
+      const err = next.firstCall.args[0];
+      expect(err).to.be.instanceOf(CsrfError);
+      expect(err.status).to.equal(403);
+      expect(err.code).to.equal("BAD_CSRF_TOKEN");
+    });
+  });
+
+  describe("safe methods", () => {
+    ["GET", "HEAD", "OPTIONS"].forEach((method) => {
+      it(`sets res.locals.csrfToken and calls next() for ${method}`, () => {
+        const req = buildReq({ method });
+        const res = buildRes();
+
+        csrf({ secret: SECRET })(req, res, next);
+
+        expect(next).to.have.been.calledOnceWithExactly();
+        expect(res.locals.csrfToken).to.be.a("string");
+        expect(
+          token.verify([SECRET], req.session.csrfSecret, res.locals.csrfToken),
+        ).to.equal(true);
+      });
+    });
+
+    it("generates and saves a session csrf secret when missing", () => {
+      const req = buildReq({ session: {} });
+
+      csrf({ secret: SECRET })(req, buildRes(), next);
+
+      expect(req.session.csrfSecret).to.be.a("string");
+      expect(req.session.csrfSecret.length).to.be.greaterThan(0);
+    });
+
+    it("reuses an existing session csrf secret", () => {
+      const session = {};
+      const middleware = csrf({ secret: SECRET });
+
+      middleware(buildReq({ session }), buildRes(), sinon.fake());
+      const first = session.csrfSecret;
+      middleware(buildReq({ session }), buildRes(), sinon.fake());
+
+      expect(session.csrfSecret).to.equal(first);
+    });
+
+    it("returns a fresh token on each request within the same session", () => {
+      const middleware = csrf({ secret: SECRET });
+
+      const res1 = buildRes();
+      middleware(buildReq(), res1, sinon.fake());
+      const res2 = buildRes();
+      middleware(buildReq(), res2, sinon.fake());
+
+      expect(res1.locals.csrfToken).to.not.equal(res2.locals.csrfToken);
+    });
+  });
+
+  describe("unsafe methods", () => {
+    let middleware;
+    let validToken;
+
+    beforeEach(() => {
+      middleware = csrf({ secret: SECRET });
+      validToken = token.create([SECRET], SESSION_CSRF_SECRET);
+    });
+
+    ["POST", "PUT", "PATCH", "DELETE"].forEach((method) => {
+      it(`accepts a valid token in req.body._csrf for ${method}`, () => {
+        const req = buildReq({ method, body: { _csrf: validToken } });
+        middleware(req, buildRes(), next);
+
+        expect(next).to.have.been.calledOnceWithExactly();
+      });
+    });
+
+    it("accepts a valid token in the x-csrf-token header", () => {
+      const req = buildReq({
+        method: "POST",
+        headers: { "x-csrf-token": validToken },
+      });
+      middleware(req, buildRes(), next);
+
+      expect(next).to.have.been.calledOnceWithExactly();
+    });
+
+    it("prefers the body field over the header", () => {
+      const req = buildReq({
+        method: "POST",
+        body: { _csrf: validToken },
+        headers: { "x-csrf-token": "invalid_token" },
+      });
+      middleware(req, buildRes(), next);
+
+      expect(next).to.have.been.calledOnceWithExactly();
+    });
+
+    it("calls next with CsrfError when token is missing", () => {
+      const req = buildReq({ method: "POST" });
+      middleware(req, buildRes(), next);
+
+      const err = next.firstCall.args[0];
+      expect(err).to.be.instanceOf(CsrfError);
+      expect(err.status).to.equal(403);
+      expect(err.code).to.equal("BAD_CSRF_TOKEN");
+    });
+
+    it("calls next with CsrfError when token is invalid", () => {
+      const req = buildReq({ method: "POST", body: { _csrf: "BAAD.F00D" } });
+      middleware(req, buildRes(), next);
+
+      expect(next.firstCall.args[0]).to.be.instanceOf(CsrfError);
+    });
+
+    it("rejects a token created for a different session", () => {
+      const otherToken = token.create([SECRET], "other-session-secret");
+      const req = buildReq({ method: "POST", body: { _csrf: otherToken } });
+      middleware(req, buildRes(), next);
+
+      expect(next.firstCall.args[0]).to.be.instanceOf(CsrfError);
+    });
+
+    it("sets res.locals.csrfToken when verification succeeds", () => {
+      const req = buildReq({ method: "POST", body: { _csrf: validToken } });
+      const res = buildRes();
+      middleware(req, res, next);
+
+      expect(res.locals.csrfToken).to.be.a("string");
+    });
+  });
+
+  describe("secret rotation", () => {
+    it("accepts a POST with a token signed by a previously-accepted secret", () => {
+      const oldToken = token.create(["old-secret"], SESSION_CSRF_SECRET);
+      const middleware = csrf({ secret: ["new-secret", "old-secret"] });
+      const req = buildReq({ method: "POST", body: { _csrf: oldToken } });
+
+      middleware(req, buildRes(), next);
+
+      expect(next).to.have.been.calledOnceWithExactly();
+    });
+
+    it("signs new tokens with the first secret during rotation", () => {
+      const middleware = csrf({ secret: ["new-secret", "old-secret"] });
+      const req = buildReq({ method: "GET" });
+      const res = buildRes();
+
+      middleware(req, res, next);
+
+      expect(
+        token.verify(
+          ["new-secret"],
+          req.session.csrfSecret,
+          res.locals.csrfToken,
+        ),
+      ).to.equal(true);
+      expect(
+        token.verify(
+          ["old-secret"],
+          req.session.csrfSecret,
+          res.locals.csrfToken,
+        ),
+      ).to.equal(false);
+    });
+
+    it("rejects tokens signed by the old secret once it's removed from the list", () => {
+      const oldToken = token.create(["old-secret"], SESSION_CSRF_SECRET);
+      const middleware = csrf({ secret: "new-secret" });
+      const req = buildReq({ method: "POST", body: { _csrf: oldToken } });
+
+      middleware(req, buildRes(), next);
+
+      expect(next.firstCall.args[0]).to.be.instanceOf(CsrfError);
+    });
+  });
+});

--- a/src/lib/csrf/token.js
+++ b/src/lib/csrf/token.js
@@ -1,0 +1,62 @@
+const crypto = require("node:crypto");
+
+const SALT_BYTES = 16;
+const SESSION_SECRET_BYTES = 32;
+const TOKEN_SEPARATOR = ".";
+
+const toBase64Url = (buffer) => buffer.toString("base64url");
+
+const setSessionSecret = () =>
+  toBase64Url(crypto.randomBytes(SESSION_SECRET_BYTES));
+
+const hmac = (consumerSecret, currentSessionCsrfSecret, salt) =>
+  toBase64Url(
+    crypto
+      .createHmac(
+        "sha256",
+        `${consumerSecret.length}:${consumerSecret}:${currentSessionCsrfSecret}`,
+      )
+      .update(salt)
+      .digest(),
+  );
+
+const timingSafeEqualString = (a, b) => {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return crypto.timingSafeEqual(bufA, bufB);
+};
+
+const create = (consumerSecrets, currentSessionCsrfSecret) => {
+  const salt = toBase64Url(crypto.randomBytes(SALT_BYTES));
+  return `${salt}${TOKEN_SEPARATOR}${hmac(consumerSecrets[0], currentSessionCsrfSecret, salt)}`;
+};
+
+const verify = (consumerSecrets, currentSessionCsrfSecret, token) => {
+  if (typeof token !== "string") return false;
+
+  const separatorIndex = token.indexOf(TOKEN_SEPARATOR);
+  if (separatorIndex <= 0 || separatorIndex === token.length - 1) return false;
+
+  const salt = token.slice(0, separatorIndex);
+  const provided = token.slice(separatorIndex + 1);
+
+  let matched = false;
+  for (const secret of consumerSecrets) {
+    if (
+      timingSafeEqualString(
+        provided,
+        hmac(secret, currentSessionCsrfSecret, salt),
+      )
+    ) {
+      matched = true;
+    }
+  }
+  return matched;
+};
+
+module.exports = {
+  create,
+  verify,
+  setSessionSecret,
+};

--- a/src/lib/csrf/token.test.js
+++ b/src/lib/csrf/token.test.js
@@ -1,0 +1,154 @@
+const token = require("./token");
+
+describe("lib/csrf/token", () => {
+  const consumerSecrets = ["hunter2"]; // pragma: allowlist secret
+  const currentSessionCsrfSecret = "top-secret"; // pragma: allowlist secret
+
+  describe("createSessionSecret", () => {
+    it("returns a non-empty string", () => {
+      const secret = token.setSessionSecret();
+      expect(secret).to.be.a("string");
+      expect(secret.length).to.be.greaterThan(0);
+    });
+
+    it("returns a different value each call", () => {
+      expect(token.setSessionSecret()).to.not.equal(token.setSessionSecret());
+    });
+  });
+
+  describe("create / verify", () => {
+    it("creates a token that verifies with the same secrets", () => {
+      const t = token.create(consumerSecrets, currentSessionCsrfSecret);
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, t),
+      ).to.equal(true);
+    });
+
+    it("produces a fresh salt on each call", () => {
+      const a = token.create(consumerSecrets, currentSessionCsrfSecret);
+      const b = token.create(consumerSecrets, currentSessionCsrfSecret);
+      expect(a).to.not.equal(b);
+    });
+
+    it("signs with the first secret in the list", () => {
+      const t = token.create(["new", "old"], currentSessionCsrfSecret);
+      expect(token.verify(["new"], currentSessionCsrfSecret, t)).to.equal(true);
+      expect(token.verify(["old"], currentSessionCsrfSecret, t)).to.equal(
+        false,
+      );
+    });
+
+    it("rejects a token signed with a different consumer secret", () => {
+      const t = token.create(["Tr0ub4dor&3"], currentSessionCsrfSecret);
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, t),
+      ).to.equal(false);
+    });
+
+    it("rejects a token signed with a different session secret", () => {
+      const t = token.create(consumerSecrets, "not-my-session-secret");
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, t),
+      ).to.equal(false);
+    });
+
+    it("rejects a tampered signature", () => {
+      const t = token.create(consumerSecrets, currentSessionCsrfSecret);
+      const [salt, sig] = t.split(".");
+      const tampered = `${salt}.${sig.slice(0, -1)}${sig.endsWith("A") ? "B" : "A"}`;
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, tampered),
+      ).to.equal(false);
+    });
+
+    it("rejects a tampered salt", () => {
+      const t = token.create(consumerSecrets, currentSessionCsrfSecret);
+      const [salt, sig] = t.split(".");
+      const tampered = `${salt.slice(0, -1)}${salt.endsWith("A") ? "B" : "A"}.${sig}`;
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, tampered),
+      ).to.equal(false);
+    });
+
+    it("rejects mismatched signature length without throwing", () => {
+      const t = token.create(consumerSecrets, currentSessionCsrfSecret);
+      const [salt, sig] = t.split(".");
+      expect(
+        token.verify(
+          consumerSecrets,
+          currentSessionCsrfSecret,
+          `${salt}.${sig}extra`,
+        ),
+      ).to.equal(false);
+    });
+
+    it("rejects non-string tokens", () => {
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, undefined),
+      ).to.equal(false);
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, null),
+      ).to.equal(false);
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, 42),
+      ).to.equal(false);
+    });
+
+    it("rejects a token with no separator", () => {
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, "nosalt"),
+      ).to.equal(false);
+    });
+
+    it("rejects a token with an empty salt or signature", () => {
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, ".sig"),
+      ).to.equal(false);
+      expect(
+        token.verify(consumerSecrets, currentSessionCsrfSecret, "salt."),
+      ).to.equal(false);
+    });
+  });
+
+  describe("rotation window", () => {
+    it("verifies tokens signed by the old secret while both are accepted", () => {
+      const oldToken = token.create(["old"], currentSessionCsrfSecret);
+      expect(
+        token.verify(["new", "old"], currentSessionCsrfSecret, oldToken),
+      ).to.equal(true);
+    });
+
+    it("verifies tokens signed by the new secret while both are accepted", () => {
+      const newToken = token.create(["new"], currentSessionCsrfSecret);
+      expect(
+        token.verify(["new", "old"], currentSessionCsrfSecret, newToken),
+      ).to.equal(true);
+    });
+
+    it("rejects tokens once the old secret is removed", () => {
+      const oldToken = token.create(["old"], currentSessionCsrfSecret);
+      expect(
+        token.verify(["new"], currentSessionCsrfSecret, oldToken),
+      ).to.equal(false);
+    });
+
+    it("rejects tokens signed by an unknown secret even with multiple accepted", () => {
+      const rogue = token.create(["rogue"], currentSessionCsrfSecret);
+      expect(
+        token.verify(["new", "old"], currentSessionCsrfSecret, rogue),
+      ).to.equal(false);
+    });
+  });
+
+  describe("hmac key encoding", () => {
+    it("treats pairs as distinct", () => {
+      const tokenA = token.create(["foo"], "barbazqux");
+      expect(token.verify(["foobar"], "bazqux", tokenA)).to.equal(false);
+    });
+
+    it("treats pairs that share a delimiter as distinct", () => {
+      const tokenA = token.create(["foo:bar"], "bazqux");
+      expect(token.verify(["foo"], "bar:bazqux", tokenA)).to.equal(false);
+    });
+  });
+});

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,4 +9,5 @@ module.exports = {
   locals: require("./locals"),
   settings: require("./settings"),
   i18n: require("./i18next"),
+  csrf: require("./csrf"),
 };

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -3,13 +3,27 @@ const middleware = require("./middleware");
 const exampleJwt =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
+const buildMocks = () => ({
+  req: {
+    axios: { get: sinon.fake(), post: sinon.fake(), put: sinon.fake() },
+    app: { get: sinon.stub() },
+    session: {},
+    headers: {},
+    body: {},
+    query: {},
+    ip: "127.0.0.1",
+  },
+  res: { redirect: sinon.spy() },
+  next: sinon.fake(),
+});
+
 describe("oauth middleware", () => {
   let req;
   let res;
   let next;
 
   beforeEach(() => {
-    const setup = setupDefaultMocks();
+    const setup = buildMocks();
     req = setup.req;
     res = setup.res;
     next = setup.next;
@@ -407,22 +421,32 @@ describe("oauth middleware", () => {
     });
 
     context("with session.save available", () => {
+      let notifySessionSaved;
+
       beforeEach(() => {
-        req.session.save = sinon.stub().yields(null);
+        notifySessionSaved = undefined;
+        req.session.save = sinon.stub().callsFake((sessionSavedCallback) => {
+          notifySessionSaved = sessionSavedCallback;
+        });
       });
 
-      it("should save the session before redirecting", async () => {
+      it("does not redirect until the session has finished saving", async () => {
         await middleware.redirectToCallback(req, res, next);
 
-        expect(req.session.save).to.have.been.calledBefore(res.redirect);
+        expect(req.session.save).to.have.been.calledOnce;
+        expect(res.redirect).to.not.have.been.called;
+
+        notifySessionSaved(null); // success
+
+        expect(res.redirect).to.have.been.calledOnce;
       });
 
-      it("should still redirect if session save fails", async () => {
-        req.session.save = sinon.stub().yields(new Error("save failed"));
-
+      it("still redirects if the session save fails", async () => {
         await middleware.redirectToCallback(req, res, next);
 
-        expect(res.redirect).to.have.been.called;
+        notifySessionSaved(new Error("session save failed"));
+
+        expect(res.redirect).to.have.been.calledOnce;
       });
     });
   });
@@ -444,23 +468,33 @@ describe("oauth middleware", () => {
     });
 
     context("with session.save available", () => {
+      let notifySessionSaved;
+
       beforeEach(() => {
         req.app.get.withArgs("APP.PATHS.ENTRYPOINT").returns("/app/entry");
-        req.session.save = sinon.stub().yields(null);
+        notifySessionSaved = undefined;
+        req.session.save = sinon.stub().callsFake((sessionSavedCallback) => {
+          notifySessionSaved = sessionSavedCallback;
+        });
       });
 
-      it("should save the session before redirecting", async () => {
+      it("does not redirect until the session has finished saving", async () => {
         await middleware.redirectToEntryPoint(req, res, next);
 
-        expect(req.session.save).to.have.been.calledBefore(res.redirect);
+        expect(req.session.save).to.have.been.calledOnce;
+        expect(res.redirect).to.not.have.been.called;
+
+        notifySessionSaved(null); // success
+
+        expect(res.redirect).to.have.been.calledOnce;
       });
 
-      it("should still redirect if session save fails", async () => {
-        req.session.save = sinon.stub().yields(new Error("save failed"));
-
+      it("still redirects if the session save fails", async () => {
         await middleware.redirectToEntryPoint(req, res, next);
 
-        expect(res.redirect).to.have.been.called;
+        notifySessionSaved(new Error("session save failed"));
+
+        expect(res.redirect).to.have.been.calledOnce;
       });
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- add new csrf protection middleware for non-hmpo-formwizard apps
- begin process of decoupling unit tests from reqres (starting with oauth2 middleware)

### Why did it change

- cri fronts **not** using `hmpo-formwizard` (currently open banking) need csrf protection, common express is a good home for this

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
