### PR TITLE
fix: GET /authorization throws with native fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "16.0.0",
+      "version": "16.0.1",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -100,18 +100,20 @@ module.exports = {
         ),
       };
 
-      const authCodeResponse = await req.customFetch(authorizationPath, {
-        headers,
-        jsonBody: {
-          params: {
-            client_id: req.session.authParams.client_id,
-            state: req.session.authParams.state,
-            redirect_uri: req.session.authParams.redirect_uri,
-            response_type: "code",
-            scope: "openid",
-          },
+      const authorizationQuery = new URLSearchParams({
+        client_id: req.session.authParams.client_id,
+        state: req.session.authParams.state,
+        redirect_uri: req.session.authParams.redirect_uri,
+        response_type: "code",
+        scope: "openid",
+      }).toString();
+
+      const authCodeResponse = await req.customFetch(
+        `${authorizationPath}?${authorizationQuery}`,
+        {
+          headers,
         },
-      });
+      );
 
       const authCodeBody = await authCodeResponse.json();
 

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -314,23 +314,17 @@ describe("oauth middleware", () => {
       it("should call the auth code endpoint with the correct parameters", async function () {
         await middleware.retrieveAuthorizationCode(req, res, next);
 
-        expect(req.customFetch).to.have.been.calledWith("/api/authorize", {
-          headers: {
-            "session-id": req.session.tokenId,
-            session_id: req.session.tokenId,
-            "txma-audit-encoded": "dummy-txma-header",
-            "x-forwarded-for": "127.0.0.1",
-          },
-          jsonBody: {
-            params: {
-              client_id: req.session.authParams.client_id,
-              redirect_uri: req.session.authParams.redirect_uri,
-              response_type: "code",
-              scope: "openid",
-              state: req.session.authParams.state,
+        expect(req.customFetch).to.have.been.calledWith(
+          "/api/authorize?client_id=test_client&state=sT%40t3&redirect_uri=http%3A%2F%2Fexample.net%2F&response_type=code&scope=openid",
+          {
+            headers: {
+              "session-id": req.session.tokenId,
+              session_id: req.session.tokenId,
+              "txma-audit-encoded": "dummy-txma-header",
+              "x-forwarded-for": "127.0.0.1",
             },
           },
-        });
+        );
       });
 
       context("with API result", () => {


### PR DESCRIPTION
## Proposed changes

### Why did it change
Any journey that reaches `/oauth2/callback` redirects to the relying party with `error=server_error&error_description=general error` instead of a successful authorization code.

This is because `retrieveAuthorizationCode` calls the `GET /authorization` endpoint like this:

```js
  await req.customFetch(authorizationPath, {
    headers,
    jsonBody: { params: { client_id, state, redirect_uri, response_type, scope } },
  });
```

jsonBody sets a request body but no method, so customFetch defaults to GET then fetch throws `TypeError: Request with GET/HEAD method cannot have body.` In v15 (axios) these were query-string params `(req.axios.get(path, { params, headers }))`, not a request body.


### Issue tracking

- OJ-3738
