### PR TITLE
OJ-3696: Fix npm publish script to support legacy versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
+      - name: Get latest release tag
+        id: get-latest-tag
+        run: echo "tag=$(gh release view --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
+
       - name: Publish
         uses: govuk-one-login/github-actions/node/run-script@4616241694c035be4ea4a10fc0fe6521c0f079f8
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
-          script: npm publish --provenance --access public
+          script: npm publish --provenance --access public --tag ${{ steps.get-latest-tag.outputs.tag == github.ref_name && github.ref_type == 'tag' && 'latest' || 'legacy' }}


### PR DESCRIPTION
## Proposed changes

### What changed

- Fixed npm publish script to explicitly specify a 'legacy' tag when the current git tag is not the same as that of the latest GitHub release

### Why did it change

- We received an error when publishing v15.1.1 because npm (correctly) refused to move the 'latest' tag to v15.1.1 when versions with higher semvers already existed
- npm does not allow the creation of tags that match semver syntax, as they share a namespace with the versions themselves - so for example `npm install package@v15` must always predictably install the highest semver with a major version of `15`. They recommend avoiding tags starting with `v` or a digit entirely. In practice that means tag names should be words, and 'legacy' seemed like a good option.

### Issue tracking

- OJ-3696

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
