### PR TITLE
fix: loosen check in handleHttpError and always try-parse as JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.0.2",
+  "version": "16.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "16.0.2",
+      "version": "16.0.3",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.0.2",
+  "version": "16.0.3",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -8,13 +8,11 @@ const DEFAULT_ERROR_DESCRIPTION = "general error";
 
 async function handleHttpError(httpError) {
   let responseObject;
-  if (httpError.headers?.get("Content-Type") === "application/json") {
+  if (httpError.body) {
     try {
       responseObject = JSON.parse(httpError.body);
     } catch {
-      logger.error(
-        `Failed to parse HTTP response body despite "application/json" header`,
-      );
+      logger.warn("Unable to parse HTTP response body as JSON");
     }
   }
 

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -6,15 +6,13 @@ const { redirectAsErrorToCallback } = proxyquire("./error-handling", {
   "./oauth": oAuthStub,
 });
 
-function buildErrorWithBody(body) {
+function buildErrorWithBody(body, contentType = "application/json") {
   return new CustomFetchHttpError(
     {
       status: 400,
       statusText: "Bad Request",
       ok: false,
-      headers: new Headers({
-        "Content-Type": "application/json",
-      }),
+      headers: new Headers(contentType ? { "Content-Type": contentType } : {}),
     },
     JSON.stringify(body),
   );
@@ -264,6 +262,140 @@ describe("error-handling", () => {
       });
     });
 
+    context("with HTTP errors and no Content-Type header", () => {
+      beforeEach(() => {
+        err = buildErrorWithBody(
+          {
+            redirect_uri: "http://error.example.org",
+            oauth_error: {
+              error_description: "gateway",
+              error: "server_error",
+            },
+          },
+          null,
+        );
+      });
+
+      it("should still parse the body and override error values", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+              error: {
+                code: "server_error",
+                description: "gateway",
+              },
+            },
+          }),
+        );
+      });
+    });
+
+    context("with HTTP errors and a Content-Type charset suffix", () => {
+      beforeEach(() => {
+        err = buildErrorWithBody(
+          {
+            redirect_uri: "http://error.example.org",
+            oauth_error: {
+              error_description: "gateway",
+              error: "server_error",
+            },
+          },
+          "application/json; charset=utf-8",
+        );
+      });
+
+      it("should still parse the body and override error values", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+              error: {
+                code: "server_error",
+                description: "gateway",
+              },
+            },
+          }),
+        );
+      });
+    });
+
+    context("with an HTTP error body that is not valid JSON", () => {
+      let warn;
+
+      beforeEach(async () => {
+        warn = require("../bootstrap/lib/logger").get().warn;
+        warn.resetHistory();
+
+        err = new CustomFetchHttpError(
+          {
+            status: 500,
+            statusText: "Internal Server Error",
+            ok: false,
+            headers: new Headers(),
+          },
+          "<html>not json</html>",
+        );
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should log a warning that the body could not be parsed", () => {
+        expect(warn).to.have.been.calledWith(
+          "Unable to parse HTTP response body as JSON",
+        );
+      });
+
+      it("should fall back to the default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: { code: "server_error", description: "general error" },
+            },
+          }),
+        );
+      });
+    });
+
+    context("with an HTTP error that has no body", () => {
+      let warn;
+
+      beforeEach(async () => {
+        warn = require("../bootstrap/lib/logger").get().warn;
+        warn.resetHistory();
+
+        err = new CustomFetchHttpError(
+          {
+            status: 500,
+            statusText: "Internal Server Error",
+            ok: false,
+            headers: new Headers(),
+          },
+          "",
+        );
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not attempt to parse the body or log a warning", () => {
+        expect(warn).not.to.have.been.called;
+      });
+
+      it("should fall back to the default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
+          sinon.match({
+            authParams: {
+              error: { code: "server_error", description: "general error" },
+            },
+          }),
+        );
+      });
+    });
+
     context("with default Error object", () => {
       beforeEach(async () => {
         err = new Error("error message");
@@ -330,6 +462,31 @@ describe("error-handling", () => {
       });
 
       it("should call next with err", () => {
+        expect(next).to.have.been.calledWith(
+          sinon.match
+            .instanceOf(Error)
+            .and(sinon.match.has("message", "Missing redirect_uri")),
+        );
+      });
+    });
+
+    context("with no redirect_uri but an existing session", () => {
+      beforeEach(async () => {
+        err = new Error("some other error");
+
+        req.session = {
+          tokenId: "some-token-id",
+          authParams: { redirect_uri: undefined, state: undefined },
+        };
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.to.have.been.called;
+      });
+
+      it("should call next with a 'Missing redirect_uri' error", () => {
         expect(next).to.have.been.calledWith(
           sinon.match
             .instanceOf(Error)


### PR DESCRIPTION
## Proposed changes

### What changed
Loosen guard around handleHttpError and always try parse json to match Axios's behavior. 

### Issue tracking

- OJ-3739
