### PR TITLE
OJ-3667: add `govuk_signin_journey_id` to pino-http logger context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.0.3",
+  "version": "16.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "16.0.3",
+      "version": "16.1.0",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.0.3",
+  "version": "16.1.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/bootstrap/middleware/index.js
+++ b/src/bootstrap/middleware/index.js
@@ -39,6 +39,7 @@ const addRequestContext = (req, res, val) => {
     ipvSessionId: safeReq.session?.ipvSessionId,
     sessionId: safeReq.session?.id,
     context: safeReq.session?.context ?? undefined,
+    govuk_signin_journey_id: safeReq.session?.govuk_signin_journey_id,
   };
 };
 

--- a/src/routes/oauth2/middleware.js
+++ b/src/routes/oauth2/middleware.js
@@ -61,6 +61,8 @@ module.exports = {
         req.session.tokenId = apiBody["session_id"];
         req.session.authParams.state = apiBody.state;
         req.session.authParams.redirect_uri = apiBody.redirect_uri;
+        req.session.govuk_signin_journey_id =
+          apiBody["govuk_signin_journey_id"];
       }
       return next();
     } catch (error) {

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -178,6 +178,7 @@ describe("oauth middleware", () => {
             session_id: "abc1234",
             state: "rAnd0m-i5ed_STring",
             redirect_uri: "http://example.org:9001/callback",
+            govuk_signin_journey_id: "test-journey-id",
           });
           req.customFetch = sinon.fake.returns(response);
 
@@ -195,6 +196,11 @@ describe("oauth middleware", () => {
         it("should save 'redirect_uri' into req.session.authParams", () => {
           expect(req.session.authParams.redirect_uri).to.equal(
             "http://example.org:9001/callback",
+          );
+        });
+        it("should save 'govuk_signin_journey_id' into req.session", () => {
+          expect(req.session.govuk_signin_journey_id).to.equal(
+            "test-journey-id",
           );
         });
         it("should call next", function () {


### PR DESCRIPTION
## Proposed changes

### Why did it change
The session lambda now emits the `govuk_signin_journey_id` as done in this PR in common-lambdas: https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/733

Note: Not to be merged until the common-lambdas PR ^ has been merged and OAuth common has been synced 

This PR now takes that value and adds it to the logging context so that we can correlate BE/FE logs together.

### Issue tracking
- [OJ-3667](https://govukverify.atlassian.net/browse/OJ-3667)


[OJ-3667]: https://govukverify.atlassian.net/browse/OJ-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ