### PR TITLE
OJ-3696: Fix publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG=gh release view --json tagName --jq .tagName
+          TAG="$(gh release view --json tagName --jq .tagName)"
           echo "Identified latest release tag: '$TAG'"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Resolved a rookie shell scripting error

### Why did it change

- We need to be able to retrieve the latest GitHub release tag to identify which tag to use when publishing to npm

### Issue tracking

- OJ-3696
- OJ-3667

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
