### PR TITLE
OJ-3696: Checkout repo before fetching releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Get latest release tag
         id: get-latest-tag
         env:


### PR DESCRIPTION
## Proposed changes

### What changed

- Checkout repo before running the `gh` CLI

### Why did it change

- We need to be able to retrieve the latest GitHub release tag to identify which tag to use when publishing to npm

### Issue tracking

- OJ-3696
- OJ-3667

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
