### PR TITLE
BAU: Backport npm publish fixes to v15 branch (no code change)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Get latest release tag
         id: get-latest-tag
-        run: echo "tag=$(gh release view --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="$(gh release view --json tagName --jq .tagName)"
+          echo "Identified latest release tag: '$TAG'"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Publish
         uses: govuk-one-login/github-actions/node/run-script@4616241694c035be4ea4a10fc0fe6521c0f079f8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "15.1.1",
+      "version": "15.1.2",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
## Proposed changes

### What changed

- Backported fixes to the publish workflow from `main`

### Why did it change

- The workflow was previously always publishing to `legacy` due to permissions errors

### Issue tracking

- OJ-3696

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
