### PR TITLE
fix: static assets from erroring live journeys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "16.1.0",
+      "version": "16.2.0",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/bootstrap/middleware/public.js
+++ b/src/bootstrap/middleware/public.js
@@ -43,6 +43,9 @@ const middleware = ({
     ),
   );
 
+  router.use(urls.public, (req, res) => res.sendStatus(404));
+  router.use(urls.publicImages, (req, res) => res.sendStatus(404));
+
   return router;
 };
 

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -34,6 +34,19 @@ module.exports = {
       return next(err);
     }
 
+    const assetPath = req.app?.locals?.assetPath || "/public";
+
+    if (req.path?.startsWith(assetPath)) {
+      return next(err);
+    }
+
+    logger.error("Handling error in redirectAsErrorToCallback", {
+      errorName: err?.name,
+      errorCode: err?.code,
+      errorStatus: err?.status,
+      path: req.path,
+    });
+
     let outputData = {
       code: DEFAULT_ERROR_CODE,
       description: DEFAULT_ERROR_DESCRIPTION,

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -28,6 +28,24 @@ async function handleHttpError(httpError) {
   };
 }
 
+async function resolveErrorOutput(err) {
+  const outputData = {
+    code: DEFAULT_ERROR_CODE,
+    description: DEFAULT_ERROR_DESCRIPTION,
+  };
+  let redirect_uri;
+
+  if (err instanceof CustomFetchHttpError) {
+    const httpData = await handleHttpError(err);
+
+    if (httpData.code) outputData.code = httpData.code;
+    if (httpData.description) outputData.description = httpData.description;
+    if (httpData.redirect_uri) redirect_uri = httpData.redirect_uri;
+  }
+
+  return { outputData, redirect_uri };
+}
+
 module.exports = {
   redirectAsErrorToCallback: async (err, req, res, next) => {
     if (err.code === "MISSING_SESSION_DATA" && err.status === 401) {
@@ -47,20 +65,11 @@ module.exports = {
       path: req.path,
     });
 
-    let outputData = {
-      code: DEFAULT_ERROR_CODE,
-      description: DEFAULT_ERROR_DESCRIPTION,
-    };
+    const { outputData, redirect_uri: httpRedirectUri } =
+      await resolveErrorOutput(err);
 
-    let redirect_uri = req.session?.authParams?.redirect_uri;
-
-    if (err instanceof CustomFetchHttpError) {
-      const httpData = await handleHttpError(err);
-
-      if (httpData.code) outputData.code = httpData.code;
-      if (httpData.description) outputData.description = httpData.description;
-      if (httpData.redirect_uri) redirect_uri = httpData.redirect_uri;
-    }
+    const redirect_uri =
+      httpRedirectUri || req.session?.authParams?.redirect_uri;
 
     if (redirect_uri) {
       try {

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -52,18 +52,19 @@ module.exports = {
       return next(err);
     }
 
-    const assetPath = req.app?.locals?.assetPath || "/public";
-
-    if (req.path?.startsWith(assetPath)) {
-      return next(err);
-    }
-
     logger.error("Handling error in redirectAsErrorToCallback", {
       errorName: err?.name,
       errorCode: err?.code,
       errorStatus: err?.status,
       path: req.path,
     });
+
+    // Ensure that missing public assets do not redirect to
+    // IPV core error callback silently
+    const assetPath = req.app?.locals?.assetPath || "/public";
+    if (req.path?.startsWith(assetPath)) {
+      return next(err);
+    }
 
     const { outputData, redirect_uri: httpRedirectUri } =
       await resolveErrorOutput(err);

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -518,6 +518,26 @@ describe("error-handling", () => {
       });
     });
 
+    context("with a static asset request", () => {
+      beforeEach(async () => {
+        err = new Error(
+          "Cannot read properties of undefined (reading 'language')",
+        );
+        req.path = "/public/govuk/govuk-frontend.min.js.map";
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not redirect the asset request to the callback", () => {
+        expect(res.redirect).not.to.have.been.called;
+        expect(oAuthStub.buildRedirectUrl).not.to.have.been.called;
+      });
+
+      it("should pass the error through to next", () => {
+        expect(next).to.have.been.calledWith(err);
+      });
+    });
+
     context("MISSING_SESSION_DATA error", () => {
       beforeEach(() => {
         err = {

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -30,7 +30,7 @@ describe("Public static assets", () => {
       const router = publicMiddleware();
 
       express.static.should.have.callCount(3);
-      router.use.should.have.callCount(3);
+      router.use.should.have.callCount(5);
 
       router.use
         .getCall(0)
@@ -64,6 +64,13 @@ describe("Public static assets", () => {
           APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
           { maxAge: 86400000 },
         );
+
+      router.use
+        .getCall(3)
+        .should.have.been.calledWith("/public", sinon.match.func);
+      router.use
+        .getCall(4)
+        .should.have.been.calledWith("/public/images", sinon.match.func);
     });
 
     it("adds hmpo-components assets when hmpoComponentsDir is provided", () => {
@@ -74,7 +81,7 @@ describe("Public static assets", () => {
       publicMiddleware({ hmpoComponentsDir });
 
       express.static.should.have.callCount(4);
-      router.use.should.have.callCount(4);
+      router.use.should.have.callCount(6);
 
       router.use
         .getCall(2)


### PR DESCRIPTION
## Proposed changes

### What changed
When users requested public assets that didn't exist, the full middleware stack would attempt to handle the response and fail, resulting in a 302 redirect to the OAuth callback with `server_error`. This could cause journeys to end silently in the case where browsers requested non-existent resources in the background, resulting in failed journeys once the user completed the CRI.

See: https://govukverify.atlassian.net/wiki/spaces/OJ/pages/6777471007/Frontends+serving+302+redirects+when+asked+for+public+assets

## Issue Tracking
[OJ-3799](https://govukverify.atlassian.net/browse/OJ-3799)

[OJ-3799]: https://govukverify.atlassian.net/browse/OJ-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ