### PR TITLE
Backport v15 fix static asset error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.1.2",
+  "version": "15.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "15.1.2",
+      "version": "15.2.0",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "15.1.2",
+  "version": "15.2.0",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/bootstrap/middleware/public.js
+++ b/src/bootstrap/middleware/public.js
@@ -43,6 +43,9 @@ const middleware = ({
     ),
   );
 
+  router.use(urls.public, (req, res) => res.sendStatus(404));
+  router.use(urls.publicImages, (req, res) => res.sendStatus(404));
+
   return router;
 };
 

--- a/src/lib/error-handling.js
+++ b/src/lib/error-handling.js
@@ -31,6 +31,20 @@ module.exports = {
       return next(err);
     }
 
+    logger.error("Handling error in redirectAsErrorToCallback", {
+      errorName: err?.name,
+      errorCode: err?.code,
+      errorStatus: err?.status,
+      path: req.path,
+    });
+
+    // Ensure that missing public assets do not redirect to
+    // IPV core error callback silently
+    const assetPath = req.app?.locals?.assetPath || "/public";
+    if (req.path?.startsWith(assetPath)) {
+      return next(err);
+    }
+
     if (
       !redirect_uri &&
       !req.session?.tokenId &&

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -374,6 +374,24 @@ describe("error-handling", () => {
       });
     });
 
+    context("with a static asset request", () => {
+      beforeEach(async () => {
+        err = new Error("asset error");
+        req.path = "/public/govuk/govuk-frontend.min.js.map";
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not redirect the asset request to the callback", () => {
+        expect(res.redirect).not.to.have.been.called;
+        expect(oAuthStub.buildRedirectUrl).not.to.have.been.called;
+      });
+
+      it("should call next with err", () => {
+        expect(next).to.have.been.calledWith(err);
+      });
+    });
+
     context("MISSING_SESSION_DATA error", () => {
       beforeEach(() => {
         err = {

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -30,7 +30,7 @@ describe("Public static assets", () => {
       const router = publicMiddleware();
 
       express.static.should.have.callCount(3);
-      router.use.should.have.callCount(3);
+      router.use.should.have.callCount(5);
 
       router.use
         .getCall(0)
@@ -64,6 +64,13 @@ describe("Public static assets", () => {
           APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
           { maxAge: 86400000 },
         );
+
+      router.use
+        .getCall(3)
+        .should.have.been.calledWith("/public", sinon.match.func);
+      router.use
+        .getCall(4)
+        .should.have.been.calledWith("/public/images", sinon.match.func);
     });
 
     it("adds hmpo-components assets when hmpoComponentsDir is provided", () => {
@@ -74,7 +81,7 @@ describe("Public static assets", () => {
       publicMiddleware({ hmpoComponentsDir });
 
       express.static.should.have.callCount(4);
-      router.use.should.have.callCount(4);
+      router.use.should.have.callCount(6);
 
       router.use
         .getCall(2)


### PR DESCRIPTION
## Proposed changes

### What changed
`getLanguageToggle` reads `req.i18n.language`, but `req.i18n` is unset for `/public` paths, so it throws a TypeError then `redirectAsErrorToCallback` catches it and, because a live session exists,
302 that background request to the OAuth callback with `server_error`, silently ending the journey.

See: https://govukverify.atlassian.net/wiki/spaces/OJ/pages/6777471007/Frontends+serving+302+redirects+when+asked+for+public+assets

## Issue Tracking
[OJ-3799](https://govukverify.atlassian.net/browse/OJ-3799)


[OJ-3799]: https://govukverify.atlassian.net/browse/OJ-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ