### PR TITLE
LIME-2068 restore public extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-one-login/di-ipv-cri-common-express",
-      "version": "16.2.1",
+      "version": "16.2.2",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-one-login/di-ipv-cri-common-express",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "description": "Express libraries and utilities for use building GOV.UK One Login Credential Issuers",
   "main": "src/index.js",
   "files": [

--- a/src/bootstrap/index.js
+++ b/src/bootstrap/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const config = require("./lib/config");
 const logger = require("./lib/logger");
 const middleware = require("./middleware");
+const { notFoundFallback } = require("./middleware/public");
 const redisClient = require("./lib/redis-client");
 const {
   configure: configureOverloadProtection,
@@ -47,6 +48,10 @@ const setup = (
   const staticRouter = express.Router();
   staticRouter.use(protect);
   app.use(staticRouter);
+
+  if (options.public !== false) {
+    app.use(notFoundFallback({ urls: app.locals.urls }));
+  }
 
   if (options.session !== false)
     middleware.session(app, {

--- a/src/bootstrap/middleware/public.js
+++ b/src/bootstrap/middleware/public.js
@@ -46,12 +46,7 @@ const middleware = ({
   return router;
 };
 
-const notFoundFallback = ({
-  urls: { public: pub, publicImages } = {
-    public: "/public",
-    publicImages: "/public/images",
-  },
-} = {}) => {
+const notFoundFallback = ({ urls: { public: pub, publicImages } }) => {
   const router = express.Router();
   router.use(pub, (_req, res) => res.sendStatus(404));
   router.use(publicImages, (_req, res) => res.sendStatus(404));

--- a/src/bootstrap/middleware/public.js
+++ b/src/bootstrap/middleware/public.js
@@ -43,12 +43,22 @@ const middleware = ({
     ),
   );
 
-  router.use(urls.public, (req, res) => res.sendStatus(404));
-  router.use(urls.publicImages, (req, res) => res.sendStatus(404));
+  return router;
+};
 
+const notFoundFallback = ({
+  urls: { public: pub, publicImages } = {
+    public: "/public",
+    publicImages: "/public/images",
+  },
+} = {}) => {
+  const router = express.Router();
+  router.use(pub, (_req, res) => res.sendStatus(404));
+  router.use(publicImages, (_req, res) => res.sendStatus(404));
   return router;
 };
 
 module.exports = {
   middleware,
+  notFoundFallback,
 };

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -1,6 +1,6 @@
-const publicMiddleware = require(
-  APP_ROOT + "/src/bootstrap/middleware/public",
-).middleware;
+const publicModule = require(APP_ROOT + "/src/bootstrap/middleware/public");
+const publicMiddleware = publicModule.middleware;
+const notFoundFallback = publicModule.notFoundFallback;
 const express = require("express");
 
 describe("Public static assets", () => {
@@ -30,7 +30,7 @@ describe("Public static assets", () => {
       const router = publicMiddleware();
 
       express.static.should.have.callCount(3);
-      router.use.should.have.callCount(5);
+      router.use.should.have.callCount(3);
 
       router.use
         .getCall(0)
@@ -64,13 +64,6 @@ describe("Public static assets", () => {
           APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
           { maxAge: 86400000 },
         );
-
-      router.use
-        .getCall(3)
-        .should.have.been.calledWith("/public", sinon.match.func);
-      router.use
-        .getCall(4)
-        .should.have.been.calledWith("/public/images", sinon.match.func);
     });
 
     it("adds hmpo-components assets when hmpoComponentsDir is provided", () => {
@@ -81,7 +74,7 @@ describe("Public static assets", () => {
       publicMiddleware({ hmpoComponentsDir });
 
       express.static.should.have.callCount(4);
-      router.use.should.have.callCount(6);
+      router.use.should.have.callCount(4);
 
       router.use
         .getCall(2)
@@ -95,6 +88,35 @@ describe("Public static assets", () => {
           hmpoComponentsDir + "/assets/images",
           { maxAge: 86400000 },
         );
+    });
+  });
+
+  describe("notFoundFallback", () => {
+    it("registers handlers on the public and public images paths", () => {
+      notFoundFallback({
+        urls: { public: "/public", publicImages: "/public/images" },
+      });
+
+      router.use.should.have.callCount(2);
+      router.use
+        .getCall(0)
+        .should.have.been.calledWith("/public", sinon.match.func);
+      router.use
+        .getCall(1)
+        .should.have.been.calledWith("/public/images", sinon.match.func);
+    });
+
+    it("responds with 404 for unmatched requests", () => {
+      notFoundFallback({
+        urls: { public: "/public", publicImages: "/public/images" },
+      });
+
+      const [, handler] = router.use.getCall(0).args;
+      const req = { url: "/i-dont-exist" };
+      const res = { sendStatus: sinon.stub() };
+      handler(req, res);
+
+      res.sendStatus.should.have.been.calledWithExactly(404);
     });
   });
 });

--- a/test/bootstrap/spec.index.js
+++ b/test/bootstrap/spec.index.js
@@ -21,11 +21,16 @@ describe("hmpo-app", () => {
     let staticRouter;
     let router;
     let errorRouter;
+    let publicFallbackRouter;
 
     beforeEach(() => {
       app = {
         use: sinon.stub(),
         get: sinon.stub(),
+        locals: { urls: { public: "/public", publicImages: "/public/images" } },
+      };
+      publicFallbackRouter = {
+        use: sinon.stub(),
       };
       staticRouter = {
         use: sinon.stub(),
@@ -38,8 +43,9 @@ describe("hmpo-app", () => {
       };
       sinon.stub(express, "Router");
       express.Router.onCall(0).returns(staticRouter);
-      express.Router.onCall(1).returns(router);
-      express.Router.onCall(2).returns(errorRouter);
+      express.Router.onCall(1).returns(publicFallbackRouter);
+      express.Router.onCall(2).returns(router);
+      express.Router.onCall(3).returns(errorRouter);
       sinon.stub(index.config, "get");
       sinon.stub(index.config, "setup");
       sinon.stub(index.logger, "setup");
@@ -145,6 +151,19 @@ describe("hmpo-app", () => {
       const callbackStub = sinon.stub();
       index.setup({ middlewareSetupFn: callbackStub });
       callbackStub.should.have.been.called;
+    });
+
+    it("mounts the public 404 fallback after staticRouter", () => {
+      index.setup();
+      app.use.getCall(0).should.have.been.calledWithExactly(staticRouter);
+      app.use
+        .getCall(1)
+        .should.have.been.calledWithExactly(publicFallbackRouter);
+    });
+
+    it("does not mount the public 404 fallback if public option is false", () => {
+      index.setup({ public: false });
+      express.Router.should.have.callCount(3);
     });
 
     it("calls middleware.listen with options", () => {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- move the 404 fallback out of the public sub-router and mount it after `middlewareSetupFn` and `staticRouter`, keeping the original fix while unblocking extensions

### Why did it change

- since `15.2.0` the `/public/*` sub-router now responds to missing statics with a 404 fallback rather than cascading errors into route handlers/redirects
  - this change also blocked downstream apps from extending `/public/*` (e.g. via middlewareSetupFn or attaching a handler to the staticRouter)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- LIME-2068

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
