### PR TITLE
OJ-3763: Migrate from Mocha to Vitest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,13 @@ module.exports = {
   env: {
     node: true,
     es6: true,
-    es2020: true,
-    mocha: true,
+    es2022: true,
+  },
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
   },
   globals: {
-    sinon: true,
     expect: true,
     setupDefaultMocks: true,
     APP_ROOT: "readonly",
@@ -15,7 +17,7 @@ module.exports = {
     CONFIG_RESET: "readonly",
   },
   extends: ["prettier", "eslint:recommended", "plugin:prettier/recommended"],
-  ignorePatterns: ["wallaby.conf.js", "node_modules", "reports", "dist"],
+  ignorePatterns: ["node_modules", "reports", "dist"],
   rules: {
     "no-console": 2,
     "padding-line-between-statements": [
@@ -24,24 +26,4 @@ module.exports = {
     ],
     "no-unused-vars": ["error", { argsIgnorePattern: "(req|res|next)" }],
   },
-  overrides: [
-    {
-      files: "**/*.test.js",
-      plugins: ["mocha"],
-      extends: ["plugin:mocha/recommended"],
-      rules: {
-        "mocha/no-mocha-arrows": 0,
-        "mocha/no-setup-in-describe": 0,
-      },
-    },
-    {
-      files: "**/spec**.js",
-      plugins: ["mocha"],
-      extends: ["plugin:mocha/recommended"],
-      rules: {
-        "mocha/no-mocha-arrows": 0,
-        "mocha/no-setup-in-describe": 0,
-      },
-    },
-  ],
 };

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,9 +1,0 @@
-fail-zero: false
-spec:
-  - "**/*.test.js"
-  - "**/spec*.js"
-ignore:
-  - "**/node_modules/**"
-file:
-  - "./test/utils/mocha-helpers"
-  - "./test/bootstrap/helper.js"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -137,9 +137,9 @@
         "filename": "src/routes/oauth2/middleware.test.js",
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_verified": false,
-        "line_number": 4
+        "line_number": 6
       }
     ]
   },
-  "generated_at": "2025-01-10T17:26:01Z"
+  "generated_at": "2026-07-16T22:44:22Z"
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm install
 
 ## Tests
 
-[mocha](https://mochajs.org/) is used as the testing framework.
+[vitest](https://vitest.dev/) is used as the testing framework.
 
 To run the tests:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "16.2.2",
       "license": "MIT",
       "dependencies": {
-        "@vitest/coverage-v8": "^4.1.10",
         "async": "3.2.6",
         "body-parser": "1.20.5",
         "compression": "1.8.1",
@@ -33,12 +32,12 @@
         "overload-protection": "1.2.3",
         "pino": "10.1.0",
         "pino-http": "11.0.0",
-        "redis": "4.7.1",
-        "vitest": "4.1.10"
+        "redis": "4.7.1"
       },
       "devDependencies": {
         "@govuk-one-login/frontend-language-toggle": "2.2.2",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-mocha": "10.2.0",
@@ -54,7 +53,8 @@
         "nyc": "18.0.0",
         "prettier": "3.2.5",
         "proxyquire": "2.1.3",
-        "reqres": "3.0.1"
+        "reqres": "3.0.1",
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=20.*",
@@ -242,6 +242,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -251,6 +252,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -284,6 +286,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -342,6 +345,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -355,6 +359,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -364,6 +369,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -375,6 +381,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -385,6 +392,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -751,6 +759,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -760,12 +769,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -794,6 +805,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -875,6 +887,7 @@
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -981,6 +994,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -997,6 +1011,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1013,6 +1028,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1029,6 +1045,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,6 +1062,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1061,6 +1079,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1080,6 +1099,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1099,6 +1119,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1118,6 +1139,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1137,6 +1159,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1156,6 +1179,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1175,6 +1199,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,6 +1216,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1209,6 +1235,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1225,6 +1252,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,6 +1266,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -1348,6 +1377,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
@@ -1367,6 +1397,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1397,6 +1428,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -1407,6 +1439,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1416,12 +1449,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
@@ -1445,7 +1480,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1472,6 +1507,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
@@ -1502,6 +1538,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
       "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -1519,6 +1556,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1528,6 +1566,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
       "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.1.10",
@@ -1554,6 +1593,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
       "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -1566,6 +1606,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
       "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "4.1.10",
@@ -1579,6 +1620,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
       "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.10",
@@ -1594,6 +1636,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
       "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1603,6 +1646,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
       "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.10",
@@ -1617,6 +1661,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/a-sync-waterfall": {
@@ -1824,6 +1869,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
       "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -1835,6 +1881,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async": {
@@ -2579,6 +2626,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2706,6 +2754,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -3005,6 +3054,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -3077,6 +3127,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -4024,6 +4075,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
@@ -4371,6 +4423,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -4504,6 +4557,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -4518,6 +4572,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -4548,6 +4603,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -4689,6 +4745,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4721,6 +4778,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4741,6 +4799,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4761,6 +4820,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4781,6 +4841,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4801,6 +4862,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4821,6 +4883,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -4844,6 +4907,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -4867,6 +4931,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -4890,6 +4955,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -4913,6 +4979,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4933,6 +5000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5362,6 +5430,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5371,6 +5440,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -5588,6 +5658,7 @@
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6132,6 +6203,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
       "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -6408,12 +6480,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6563,6 +6637,7 @@
       "version": "8.5.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
       "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7189,6 +7264,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
@@ -7281,6 +7357,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7453,6 +7530,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -7568,6 +7646,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7710,6 +7789,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -7725,6 +7805,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
@@ -8013,12 +8094,14 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8028,6 +8111,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8044,6 +8128,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8061,6 +8146,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8073,6 +8159,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -8113,7 +8200,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsscmp": {
@@ -8215,7 +8302,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -8290,6 +8377,7 @@
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -8367,6 +8455,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8379,6 +8468,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/expect": "4.1.10",
@@ -8468,6 +8558,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8502,6 +8593,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -8681,7 +8773,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "16.2.2",
       "license": "MIT",
       "dependencies": {
+        "@vitest/coverage-v8": "^4.1.10",
         "async": "3.2.6",
         "body-parser": "1.20.5",
         "compression": "1.8.1",
@@ -32,13 +33,12 @@
         "overload-protection": "1.2.3",
         "pino": "10.1.0",
         "pino-http": "11.0.0",
-        "redis": "4.7.1"
+        "redis": "4.7.1",
+        "vitest": "4.1.10"
       },
       "devDependencies": {
         "@govuk-one-login/frontend-language-toggle": "2.2.2",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
-        "chai": "4.4.1",
-        "chai-as-promised": "7.1.1",
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-mocha": "10.2.0",
@@ -48,16 +48,13 @@
         "hmpo-form-wizard": "16.0.0",
         "hmpo-reqres": "2.0.1",
         "lint-staged": "15.5.2",
-        "mocha": "11.7.4",
         "nock": "^14.0.15",
         "nodemon": "3.1.0",
         "nunjucks": "3.2.4",
         "nyc": "18.0.0",
         "prettier": "3.2.5",
         "proxyquire": "2.1.3",
-        "reqres": "3.0.1",
-        "sinon": "22.0.0",
-        "sinon-chai": "3.7.0"
+        "reqres": "3.0.1"
       },
       "engines": {
         "node": ">=20.*",
@@ -245,7 +242,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -255,7 +251,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -289,7 +284,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -348,7 +342,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -356,6 +349,46 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -718,7 +751,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -728,14 +760,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -758,6 +788,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -822,6 +870,15 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -916,6 +973,272 @@
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -1021,6 +1344,12 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -1032,6 +1361,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/aws-lambda": {
@@ -1054,6 +1393,37 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -1075,7 +1445,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1097,6 +1467,157 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
@@ -1299,15 +1820,22 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "license": "MIT",
-      "engines": {
-        "node": "*"
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -1416,13 +1944,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
@@ -1581,38 +2102,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true,
-      "license": "WTFPL",
-      "dependencies": {
-        "check-error": "^1.0.2"
-      },
-      "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1627,19 +2116,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1773,71 +2249,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone-response": {
@@ -2112,19 +2523,6 @@
       "integrity": "sha512-ldHDqbpMP5VTZ/QrIQ6ikzYy4fWh8WPIfqEwetN/4Pxq/xPnWlnESGN41oam5DEwI+acHznEm1bp5Rn4bp4c0w==",
       "license": "MIT"
     },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2175,6 +2573,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2294,6 +2701,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2588,6 +3001,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2649,6 +3071,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2919,16 +3350,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -3091,16 +3512,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3389,16 +3800,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/helmet": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
@@ -3619,40 +4020,10 @@
         "node": "20.x || 22.x"
       }
     },
-    "node_modules/hmpo-reqres/node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/hmpo-reqres/node_modules/sinon": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.5.tgz",
-      "integrity": "sha512-r15s9/s+ub/d4bxNXqIUmwp6imVSdTorIRaxoecYjqTVLZ8RuoXr/4EDGwIBo6Waxn7f2gnURX9zuhAfCwaF6Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.5",
-        "@sinonjs/samsam": "^8.0.1",
-        "diff": "^7.0.0",
-        "nise": "^6.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
@@ -3960,16 +4331,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -3989,19 +4350,6 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -4023,7 +4371,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -4157,7 +4504,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -4172,7 +4518,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -4203,7 +4548,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -4339,6 +4683,267 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -4564,23 +5169,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -4750,16 +5338,6 @@
         "xtend": "^4.0.1"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -4778,6 +5356,26 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -4963,177 +5561,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mocha": {
-      "version": "11.7.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.4.tgz",
-      "integrity": "sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browser-stdout": "^1.3.1",
-        "chokidar": "^4.0.1",
-        "debug": "^4.3.5",
-        "diff": "^7.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-up": "^5.0.0",
-        "glob": "^10.4.5",
-        "he": "^1.2.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
-        "ms": "^2.1.3",
-        "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
-        "yargs-unparser": "^2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/mocha/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
@@ -5156,6 +5583,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5683,6 +6128,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -5946,21 +6404,16 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6104,6 +6557,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -6306,16 +6787,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -6714,6 +7185,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6777,7 +7281,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6824,16 +7327,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
     },
     "node_modules/serve-static": {
       "version": "1.16.3",
@@ -6956,6 +7449,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6982,52 +7481,32 @@
       }
     },
     "node_modules/sinon": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
-      "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.5.tgz",
+      "integrity": "sha512-r15s9/s+ub/d4bxNXqIUmwp6imVSdTorIRaxoecYjqTVLZ8RuoXr/4EDGwIBo6Waxn7f2gnURX9zuhAfCwaF6Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@sinonjs/samsam": "^10.0.2",
-        "diff": "^9.0.0"
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
       }
     },
-    "node_modules/sinon-chai": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
-      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true,
-      "license": "(BSD-2-Clause OR WTFPL)",
-      "peerDependencies": {
-        "chai": "^4.0.0",
-        "sinon": ">=4.0.0"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/samsam": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
-      "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/slice-ansi": {
@@ -7080,6 +7559,15 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7218,6 +7706,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7226,6 +7720,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -7509,6 +8009,75 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7544,7 +8113,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsscmp": {
@@ -7646,7 +8215,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -7717,6 +8286,196 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7739,6 +8498,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7748,13 +8523,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -7913,7 +8681,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -7923,119 +8691,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "lint:prettier": "prettier --check .",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:fix": "npm run lint:eslint -- --fix && npm run lint:prettier -- --write",
-    "test": "mocha",
-    "test:coverage": "nyc --reporter=lcov --reporter=text-summary npm run test",
-    "test:watch": "mocha --watch"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@vitest/coverage-v8": "^4.1.10",
     "async": "3.2.6",
     "body-parser": "1.20.5",
     "compression": "1.8.1",
@@ -62,13 +62,12 @@
     "overload-protection": "1.2.3",
     "pino": "10.1.0",
     "pino-http": "11.0.0",
-    "redis": "4.7.1"
+    "redis": "4.7.1",
+    "vitest": "4.1.10"
   },
   "devDependencies": {
     "@govuk-one-login/frontend-language-toggle": "2.2.2",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
-    "chai": "4.4.1",
-    "chai-as-promised": "7.1.1",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-mocha": "10.2.0",
@@ -78,16 +77,13 @@
     "hmpo-form-wizard": "16.0.0",
     "hmpo-reqres": "2.0.1",
     "lint-staged": "15.5.2",
-    "mocha": "11.7.4",
     "nock": "^14.0.15",
     "nodemon": "3.1.0",
     "nunjucks": "3.2.4",
     "nyc": "18.0.0",
     "prettier": "3.2.5",
     "proxyquire": "2.1.3",
-    "reqres": "3.0.1",
-    "sinon": "22.0.0",
-    "sinon-chai": "3.7.0"
+    "reqres": "3.0.1"
   },
   "peerDependencies": {
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@vitest/coverage-v8": "^4.1.10",
     "async": "3.2.6",
     "body-parser": "1.20.5",
     "compression": "1.8.1",
@@ -62,12 +61,12 @@
     "overload-protection": "1.2.3",
     "pino": "10.1.0",
     "pino-http": "11.0.0",
-    "redis": "4.7.1",
-    "vitest": "4.1.10"
+    "redis": "4.7.1"
   },
   "devDependencies": {
     "@govuk-one-login/frontend-language-toggle": "2.2.2",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-mocha": "10.2.0",
@@ -83,7 +82,8 @@
     "nyc": "18.0.0",
     "prettier": "3.2.5",
     "proxyquire": "2.1.3",
-    "reqres": "3.0.1"
+    "reqres": "3.0.1",
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",

--- a/scripts/checkTranslations.test.js
+++ b/scripts/checkTranslations.test.js
@@ -1,4 +1,5 @@
-const { expect } = require("chai");
+import { expect, describe, it } from "vitest";
+
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 
@@ -18,17 +19,17 @@ describe("checkTranslation", () => {
       warnings.shift();
       errors.shift();
 
-      expect(warnings.length).to.equal(2);
+      expect(warnings.length).toEqual(2);
 
       for (const message of warnings) {
-        expect(message).to.contain("warning");
-        expect(message).to.contain("length do not match");
+        expect(message).toContain("warning");
+        expect(message).toContain("length do not match");
       }
 
-      expect(errors.length).to.equal(4);
+      expect(errors.length).toEqual(4);
 
       for (const message of errors) {
-        expect(message).to.satisfy((val) => {
+        expect(message).toSatisfy((val) => {
           if (val.includes("ENGLISH - Missing default.root.field3")) {
             return true;
           } else if (
@@ -60,7 +61,7 @@ describe("checkTranslation", () => {
       val.includes("Translation files look good"),
     );
 
-    expect(successMessage).to.be.true;
+    expect(successMessage).toBe(true);
   });
 
   it("should pass plurals with no errors", async () => {
@@ -72,6 +73,6 @@ describe("checkTranslation", () => {
       val.includes("Translation files look good"),
     );
 
-    expect(successMessage).to.be.true;
+    expect(successMessage).toBe(true);
   });
 });

--- a/src/assets/javascript/.eslintrc.js
+++ b/src/assets/javascript/.eslintrc.js
@@ -4,8 +4,7 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    es2020: true,
-    mocha: true,
+    es2022: true,
   },
   globals: {
     dataLayer: true,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,12 +9,12 @@ describe("root module file", () => {
     );
 
     expect(typeof index.lib).toEqual("object");
-    expect(index.lib).not.toEqual(null);
+    expect(index.lib).not.toBeNull();
 
     expect(typeof index.routes).toEqual("object");
-    expect(index.routes).not.toEqual(null);
+    expect(index.routes).not.toBeNull();
 
     expect(typeof index.bootstrap).toEqual("object");
-    expect(index.bootstrap).not.toEqual(null);
+    expect(index.bootstrap).not.toBeNull();
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,17 +1,20 @@
-const { describe } = require("mocha");
+import { describe, expect, it } from "vitest";
+
 const index = require("./index");
 
 describe("root module file", () => {
   it("provides expected keys at the root", () => {
-    expect(Object.keys(index)).to.have.members(["lib", "routes", "bootstrap"]);
+    expect(Object.keys(index)).toEqual(
+      expect.arrayContaining(["lib", "routes", "bootstrap"]),
+    );
 
-    expect(typeof index.lib).to.equal("object");
-    expect(index.lib).not.to.equal(null);
+    expect(typeof index.lib).toEqual("object");
+    expect(index.lib).not.toEqual(null);
 
-    expect(typeof index.routes).to.equal("object");
-    expect(index.routes).not.to.equal(null);
+    expect(typeof index.routes).toEqual("object");
+    expect(index.routes).not.toEqual(null);
 
-    expect(typeof index.bootstrap).to.equal("object");
-    expect(index.bootstrap).not.to.equal(null);
+    expect(typeof index.bootstrap).toEqual("object");
+    expect(index.bootstrap).not.toEqual(null);
   });
 });

--- a/src/lib/csrf/middleware.test.js
+++ b/src/lib/csrf/middleware.test.js
@@ -1,3 +1,5 @@
+import { vi, expect, describe, beforeEach, it } from "vitest";
+
 const csrf = require("./middleware");
 const CsrfError = require("./error");
 const token = require("./token");
@@ -19,32 +21,32 @@ describe("lib/csrf/middleware", () => {
   let next;
 
   beforeEach(() => {
-    next = sinon.fake();
+    next = vi.fn();
   });
 
   describe("configuration", () => {
     it("throws when no secret is provided", () => {
-      expect(() => csrf()).to.throw(/secret/);
-      expect(() => csrf({})).to.throw(/secret/);
-      expect(() => csrf({ secret: "" })).to.throw(/secret/);
-      expect(() => csrf({ secret: 123 })).to.throw(/secret/);
+      expect(() => csrf()).toThrow(/secret/);
+      expect(() => csrf({})).toThrow(/secret/);
+      expect(() => csrf({ secret: "" })).toThrow(/secret/);
+      expect(() => csrf({ secret: 123 })).toThrow(/secret/);
     });
 
     it("throws when secret is an empty array", () => {
-      expect(() => csrf({ secret: [] })).to.throw(/secret/);
+      expect(() => csrf({ secret: [] })).toThrow(/secret/);
     });
 
     it("throws when secret array contains invalid entries", () => {
-      expect(() => csrf({ secret: ["valid", ""] })).to.throw(/secret/);
-      expect(() => csrf({ secret: ["valid", 42] })).to.throw(/secret/);
+      expect(() => csrf({ secret: ["valid", ""] })).toThrow(/secret/);
+      expect(() => csrf({ secret: ["valid", 42] })).toThrow(/secret/);
     });
 
     it("returns middleware when given a secret string", () => {
-      expect(csrf({ secret: SECRET })).to.be.a("function");
+      expect(typeof csrf({ secret: SECRET })).toBe("function");
     });
 
     it("returns middleware when given a secret array", () => {
-      expect(csrf({ secret: [SECRET, "previous"] })).to.be.a("function");
+      expect(typeof csrf({ secret: [SECRET, "previous"] })).toBe("function");
     });
   });
 
@@ -55,11 +57,11 @@ describe("lib/csrf/middleware", () => {
 
       csrf({ secret: SECRET })(req, buildRes(), next);
 
-      expect(next).to.have.been.calledOnce;
-      const err = next.firstCall.args[0];
-      expect(err).to.be.instanceOf(CsrfError);
-      expect(err.status).to.equal(403);
-      expect(err.code).to.equal("BAD_CSRF_TOKEN");
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(CsrfError);
+      expect(err.status).toEqual(403);
+      expect(err.code).toEqual("BAD_CSRF_TOKEN");
     });
   });
 
@@ -71,11 +73,11 @@ describe("lib/csrf/middleware", () => {
 
         csrf({ secret: SECRET })(req, res, next);
 
-        expect(next).to.have.been.calledOnceWithExactly();
-        expect(res.locals.csrfToken).to.be.a("string");
+        expect(next).toHaveBeenCalled();
+        expect(typeof res.locals.csrfToken).toBe("string");
         expect(
           token.verify([SECRET], req.session.csrfSecret, res.locals.csrfToken),
-        ).to.equal(true);
+        ).toEqual(true);
       });
     });
 
@@ -84,17 +86,17 @@ describe("lib/csrf/middleware", () => {
 
       csrf({ secret: SECRET })(req, buildRes(), next);
 
-      expect(req.session.csrfSecret).to.be.a("string");
-      expect(req.session.csrfSecret.length).to.be.greaterThan(0);
+      expect(typeof req.session.csrfSecret).toBe("string");
+      expect(req.session.csrfSecret.length).toBeGreaterThan(0);
     });
 
     it("reuses an existing session csrf secret", () => {
       const session = {};
       const middleware = csrf({ secret: SECRET });
 
-      middleware(buildReq({ session }), buildRes(), sinon.fake());
+      middleware(buildReq({ session }), buildRes(), vi.fn());
       const first = session.csrfSecret;
-      middleware(buildReq({ session }), buildRes(), sinon.fake());
+      middleware(buildReq({ session }), buildRes(), vi.fn());
 
       expect(session.csrfSecret).to.equal(first);
     });
@@ -103,9 +105,9 @@ describe("lib/csrf/middleware", () => {
       const middleware = csrf({ secret: SECRET });
 
       const res1 = buildRes();
-      middleware(buildReq(), res1, sinon.fake());
+      middleware(buildReq(), res1, vi.fn());
       const res2 = buildRes();
-      middleware(buildReq(), res2, sinon.fake());
+      middleware(buildReq(), res2, vi.fn());
 
       expect(res1.locals.csrfToken).to.not.equal(res2.locals.csrfToken);
     });
@@ -125,7 +127,7 @@ describe("lib/csrf/middleware", () => {
         const req = buildReq({ method, body: { _csrf: validToken } });
         middleware(req, buildRes(), next);
 
-        expect(next).to.have.been.calledOnceWithExactly();
+        expect(next).toHaveBeenCalled();
       });
     });
 
@@ -136,7 +138,7 @@ describe("lib/csrf/middleware", () => {
       });
       middleware(req, buildRes(), next);
 
-      expect(next).to.have.been.calledOnceWithExactly();
+      expect(next).toHaveBeenCalled();
     });
 
     it("prefers the body field over the header", () => {
@@ -147,24 +149,24 @@ describe("lib/csrf/middleware", () => {
       });
       middleware(req, buildRes(), next);
 
-      expect(next).to.have.been.calledOnceWithExactly();
+      expect(next).toHaveBeenCalled();
     });
 
     it("calls next with CsrfError when token is missing", () => {
       const req = buildReq({ method: "POST" });
       middleware(req, buildRes(), next);
 
-      const err = next.firstCall.args[0];
-      expect(err).to.be.instanceOf(CsrfError);
-      expect(err.status).to.equal(403);
-      expect(err.code).to.equal("BAD_CSRF_TOKEN");
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(CsrfError);
+      expect(err.status).toEqual(403);
+      expect(err.code).toEqual("BAD_CSRF_TOKEN");
     });
 
     it("calls next with CsrfError when token is invalid", () => {
       const req = buildReq({ method: "POST", body: { _csrf: "BAAD.F00D" } });
       middleware(req, buildRes(), next);
 
-      expect(next.firstCall.args[0]).to.be.instanceOf(CsrfError);
+      expect(next.mock.calls[0][0]).toBeInstanceOf(CsrfError);
     });
 
     it("rejects a token created for a different session", () => {
@@ -172,7 +174,7 @@ describe("lib/csrf/middleware", () => {
       const req = buildReq({ method: "POST", body: { _csrf: otherToken } });
       middleware(req, buildRes(), next);
 
-      expect(next.firstCall.args[0]).to.be.instanceOf(CsrfError);
+      expect(next.mock.calls[0][0]).toBeInstanceOf(CsrfError);
     });
 
     it("sets res.locals.csrfToken when verification succeeds", () => {
@@ -180,7 +182,7 @@ describe("lib/csrf/middleware", () => {
       const res = buildRes();
       middleware(req, res, next);
 
-      expect(res.locals.csrfToken).to.be.a("string");
+      expect(typeof res.locals.csrfToken).toBe("string");
     });
   });
 
@@ -192,7 +194,7 @@ describe("lib/csrf/middleware", () => {
 
       middleware(req, buildRes(), next);
 
-      expect(next).to.have.been.calledOnceWithExactly();
+      expect(next).toHaveBeenCalled();
     });
 
     it("signs new tokens with the first secret during rotation", () => {
@@ -208,14 +210,14 @@ describe("lib/csrf/middleware", () => {
           req.session.csrfSecret,
           res.locals.csrfToken,
         ),
-      ).to.equal(true);
+      ).toEqual(true);
       expect(
         token.verify(
           ["old-secret"],
           req.session.csrfSecret,
           res.locals.csrfToken,
         ),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects tokens signed by the old secret once it's removed from the list", () => {
@@ -225,7 +227,7 @@ describe("lib/csrf/middleware", () => {
 
       middleware(req, buildRes(), next);
 
-      expect(next.firstCall.args[0]).to.be.instanceOf(CsrfError);
+      expect(next.mock.calls[0][0]).toBeInstanceOf(CsrfError);
     });
   });
 });

--- a/src/lib/csrf/token.test.js
+++ b/src/lib/csrf/token.test.js
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 const token = require("./token");
 
 describe("lib/csrf/token", () => {
@@ -7,12 +9,12 @@ describe("lib/csrf/token", () => {
   describe("createSessionSecret", () => {
     it("returns a non-empty string", () => {
       const secret = token.setSessionSecret();
-      expect(secret).to.be.a("string");
-      expect(secret.length).to.be.greaterThan(0);
+      expect(typeof secret).toBe("string");
+      expect(secret.length).toBeGreaterThan(0);
     });
 
     it("returns a different value each call", () => {
-      expect(token.setSessionSecret()).to.not.equal(token.setSessionSecret());
+      expect(token.setSessionSecret()).not.toBe(token.setSessionSecret());
     });
   });
 
@@ -21,21 +23,19 @@ describe("lib/csrf/token", () => {
       const t = token.create(consumerSecrets, currentSessionCsrfSecret);
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, t),
-      ).to.equal(true);
+      ).toEqual(true);
     });
 
     it("produces a fresh salt on each call", () => {
       const a = token.create(consumerSecrets, currentSessionCsrfSecret);
       const b = token.create(consumerSecrets, currentSessionCsrfSecret);
-      expect(a).to.not.equal(b);
+      expect(a).not.toBe(b);
     });
 
     it("signs with the first secret in the list", () => {
       const t = token.create(["new", "old"], currentSessionCsrfSecret);
-      expect(token.verify(["new"], currentSessionCsrfSecret, t)).to.equal(true);
-      expect(token.verify(["old"], currentSessionCsrfSecret, t)).to.equal(
-        false,
-      );
+      expect(token.verify(["new"], currentSessionCsrfSecret, t)).toEqual(true);
+      expect(token.verify(["old"], currentSessionCsrfSecret, t)).toEqual(false);
     });
 
     it("rejects a token signed with a different consumer secret", () => {
@@ -49,7 +49,7 @@ describe("lib/csrf/token", () => {
       const t = token.create(consumerSecrets, "not-my-session-secret");
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, t),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects a tampered signature", () => {
@@ -58,7 +58,7 @@ describe("lib/csrf/token", () => {
       const tampered = `${salt}.${sig.slice(0, -1)}${sig.endsWith("A") ? "B" : "A"}`;
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, tampered),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects a tampered salt", () => {
@@ -67,7 +67,7 @@ describe("lib/csrf/token", () => {
       const tampered = `${salt.slice(0, -1)}${salt.endsWith("A") ? "B" : "A"}.${sig}`;
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, tampered),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects mismatched signature length without throwing", () => {
@@ -79,34 +79,34 @@ describe("lib/csrf/token", () => {
           currentSessionCsrfSecret,
           `${salt}.${sig}extra`,
         ),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects non-string tokens", () => {
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, undefined),
-      ).to.equal(false);
+      ).toEqual(false);
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, null),
-      ).to.equal(false);
+      ).toEqual(false);
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, 42),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects a token with no separator", () => {
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, "nosalt"),
-      ).to.equal(false);
+      ).toEqual(false);
     });
 
     it("rejects a token with an empty salt or signature", () => {
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, ".sig"),
-      ).to.equal(false);
+      ).toEqual(false);
       expect(
         token.verify(consumerSecrets, currentSessionCsrfSecret, "salt."),
-      ).to.equal(false);
+      ).toEqual(false);
     });
   });
 
@@ -115,40 +115,40 @@ describe("lib/csrf/token", () => {
       const oldToken = token.create(["old"], currentSessionCsrfSecret);
       expect(
         token.verify(["new", "old"], currentSessionCsrfSecret, oldToken),
-      ).to.equal(true);
+      ).toEqual(true);
     });
 
     it("verifies tokens signed by the new secret while both are accepted", () => {
       const newToken = token.create(["new"], currentSessionCsrfSecret);
       expect(
         token.verify(["new", "old"], currentSessionCsrfSecret, newToken),
-      ).to.equal(true);
+      ).toEqual(true);
     });
 
     it("rejects tokens once the old secret is removed", () => {
       const oldToken = token.create(["old"], currentSessionCsrfSecret);
-      expect(
-        token.verify(["new"], currentSessionCsrfSecret, oldToken),
-      ).to.equal(false);
+      expect(token.verify(["new"], currentSessionCsrfSecret, oldToken)).toEqual(
+        false,
+      );
     });
 
     it("rejects tokens signed by an unknown secret even with multiple accepted", () => {
       const rogue = token.create(["rogue"], currentSessionCsrfSecret);
       expect(
         token.verify(["new", "old"], currentSessionCsrfSecret, rogue),
-      ).to.equal(false);
+      ).toEqual(false);
     });
   });
 
   describe("hmac key encoding", () => {
     it("treats pairs as distinct", () => {
       const tokenA = token.create(["foo"], "barbazqux");
-      expect(token.verify(["foobar"], "bazqux", tokenA)).to.equal(false);
+      expect(token.verify(["foobar"], "bazqux", tokenA)).toEqual(false);
     });
 
     it("treats pairs that share a delimiter as distinct", () => {
       const tokenA = token.create(["foo:bar"], "bazqux");
-      expect(token.verify(["foo"], "bar:bazqux", tokenA)).to.equal(false);
+      expect(token.verify(["foo"], "bar:bazqux", tokenA)).toEqual(false);
     });
   });
 });

--- a/src/lib/custom-fetch-nock.test.js
+++ b/src/lib/custom-fetch-nock.test.js
@@ -143,7 +143,7 @@ describe("custom-fetch.js with nock stub", () => {
       nock.abortPendingRequests();
       expect(timeElapsed).to.be.closeTo(100, 10);
 
-      expect(error instanceof DOMException).toEqual(true);
+      expect(error).toBeInstanceOf(DOMException);
       expect(error.name).toEqual("TimeoutError");
       expect(error.message).toEqual("The operation was aborted due to timeout");
       hasThrown = true;

--- a/src/lib/custom-fetch-nock.test.js
+++ b/src/lib/custom-fetch-nock.test.js
@@ -1,3 +1,5 @@
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+
 const nock = require("nock");
 
 const {
@@ -8,21 +10,23 @@ const {
 describe("custom-fetch.js with nock stub", () => {
   let dummyReq = {
     app: {
-      get: sinon.stub().withArgs("API.BASE_URL").returns("https://gov.uk"),
+      get: vi.fn().mockImplementation((args) => {
+        if (args === "API.BASE_URL") return "https://gov.uk";
+      }),
     },
   };
   const res = {};
-  const next = sinon.stub();
+  const next = vi.fn();
 
   // Nock injects a stub into Node's internal HTTP code, which means we can get real fetch()
   // behaviour without making network calls
   let nockMock = nock("https://gov.uk");
 
-  before(() => {
+  beforeAll(() => {
     customFetchMiddleware(dummyReq, res, next);
   });
 
-  after(() => {
+  afterAll(() => {
     nock.restore();
   });
 
@@ -35,9 +39,9 @@ describe("custom-fetch.js with nock stub", () => {
 
     const responseBody = await response.json();
 
-    expect(response.status).to.equal(200);
-    expect(response.headers.get("someHeader")).to.equal("very good");
-    expect(responseBody).to.deep.equal({ success: true });
+    expect(response.status).toEqual(200);
+    expect(response.headers.get("someHeader")).toEqual("very good");
+    expect(responseBody).toEqual({ success: true });
   });
 
   it("handles a 4xx response correctly", async () => {
@@ -49,19 +53,19 @@ describe("custom-fetch.js with nock stub", () => {
       await dummyReq.customFetch("/failure");
     } catch (error) {
       if (error instanceof CustomFetchHttpError) {
-        expect(error.code).to.equal(418);
-        expect(error.message).to.equal(`Response not OK: I'm a Teapot`);
+        expect(error.code).toEqual(418);
+        expect(error.message).toEqual(`Response not OK: I'm a Teapot`);
 
-        expect(error.headers.get("content-type")).to.equal("application/json");
+        expect(error.headers.get("content-type")).toEqual("application/json");
 
         const responseBody = JSON.parse(error.body);
-        expect(responseBody).to.deep.equal({ coffeeForYou: false });
+        expect(responseBody).toEqual({ coffeeForYou: false });
 
         didItThrow = true;
       }
     }
 
-    expect(didItThrow).to.equal(true);
+    expect(didItThrow).toEqual(true);
   });
 
   it("handles a 5xx response correctly", async () => {
@@ -79,20 +83,18 @@ describe("custom-fetch.js with nock stub", () => {
       });
     } catch (error) {
       if (error instanceof CustomFetchHttpError) {
-        expect(error.code).to.equal(500);
-        expect(error.message).to.equal(
-          "Response not OK: Internal Server Error",
-        );
+        expect(error.code).toEqual(500);
+        expect(error.message).toEqual("Response not OK: Internal Server Error");
 
-        expect(error.headers.get("content-type")).to.equal("text/plain");
+        expect(error.headers.get("content-type")).toEqual("text/plain");
 
-        expect(error.body).to.equal("who knocked over the server");
+        expect(error.body).toEqual("who knocked over the server");
 
         didItThrow = true;
       }
     }
 
-    expect(didItThrow).to.equal(true);
+    expect(didItThrow).toEqual(true);
   });
 
   it("sends method, body and headers correctly", async () => {
@@ -110,11 +112,11 @@ describe("custom-fetch.js with nock stub", () => {
       jsonBody: { veryGood: "yes" },
     });
 
-    expect(response.status).to.equal(200);
+    expect(response.status).toEqual(200);
 
     const responseBody = await response.json();
 
-    expect(responseBody).to.deep.equal({
+    expect(responseBody).toEqual({
       yourPath: "/echo",
       yourBody: { veryGood: "yes" },
       yourHeaders: {
@@ -141,14 +143,12 @@ describe("custom-fetch.js with nock stub", () => {
       nock.abortPendingRequests();
       expect(timeElapsed).to.be.closeTo(100, 10);
 
-      expect(error instanceof DOMException).to.equal(true);
-      expect(error.name).to.equal("TimeoutError");
-      expect(error.message).to.equal(
-        "The operation was aborted due to timeout",
-      );
+      expect(error instanceof DOMException).toEqual(true);
+      expect(error.name).toEqual("TimeoutError");
+      expect(error.message).toEqual("The operation was aborted due to timeout");
       hasThrown = true;
     }
 
-    expect(hasThrown).to.equal(true);
+    expect(hasThrown).toEqual(true);
   });
 });

--- a/src/lib/custom-fetch.test.js
+++ b/src/lib/custom-fetch.test.js
@@ -1,7 +1,4 @@
-const logger = require("../bootstrap/lib/logger");
-const { PACKAGE_NAME } = require("./constants");
-
-const logInfo = logger.get(PACKAGE_NAME).info;
+import { expect, it, describe, vi, beforeEach } from "vitest";
 
 const {
   CustomFetchHttpError,
@@ -23,57 +20,69 @@ describe("custom-fetch.js with global.fetch mock", () => {
         badResponse,
         await badResponse.text(),
       );
-      expect(error.code).to.equal(418);
-      expect(error.body).to.equal("no coffee for you");
-      expect(error.message).to.equal(`Response not OK: I'm a Teapot`);
-      expect(error.headers.get("some-header")).to.equal("illegal");
+      expect(error.code).toEqual(418);
+      expect(error.body).toEqual("no coffee for you");
+      expect(error.message).toEqual(`Response not OK: I'm a Teapot`);
+      expect(error.headers.get("some-header")).toEqual("illegal");
     });
   });
 
   describe("customFetch()", () => {
     let dummyReq;
+    let loggerStub;
     const res = {};
-    const next = sinon.stub();
+    const next = vi.fn();
 
     const fetchResponse = { ok: true, statusCode: 200, text: () => "hello" };
 
-    before(() => {
-      global.fetch = sinon.stub().returns(fetchResponse);
-    });
+    global.fetch = vi.fn().mockReturnValue(fetchResponse);
 
     beforeEach(() => {
+      vi.clearAllMocks();
+
       dummyReq = {
         app: {
-          get: sinon.stub().withArgs("API.BASE_URL").returns("https://gov.uk"),
+          get: vi.fn().mockImplementation((arg) => {
+            if (arg === "API.BASE_URL") return "https://gov.uk";
+          }),
         },
       };
-      sinon.resetHistory();
+      loggerStub = LOGGER_RESET();
     });
 
     describe("customFetchMiddleware()", () => {
       it("runs the middleware to attach the customFetch function to the req object", () => {
         customFetchMiddleware(dummyReq, res, next);
-        expect(typeof dummyReq.customFetch).to.equal("function");
-        sinon.assert.calledOnce(next);
+        expect(typeof dummyReq.customFetch).toEqual("function");
+        expect(next).toHaveBeenCalledTimes(1);
       });
 
       it("calls next(error) if an error is thrown while building the fetch function", () => {
         const badReq = { ...dummyReq, headers: { forwarded: 1000 } };
 
         customFetchMiddleware(badReq, res, next);
-        sinon.assert.calledOnce(next);
-        expect(next.lastCall.firstArg).to.be.instanceof(Error);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next.mock.calls.at(-1)[0]).toBeInstanceOf(Error);
       });
 
       [
-        ["empty", { app: { get: sinon.stub().returns("") } }],
-        ["null", { app: { get: sinon.stub().returns(null) } }],
-        ["error", { app: { get: sinon.stub().throws(new Error()) } }],
+        ["empty", { app: { get: vi.fn().mockReturnValueOnce("") } }],
+        ["null", { app: { get: vi.fn().mockReturnValueOnce(null) } }],
+        [
+          "error",
+          {
+            app: {
+              get: vi.fn().mockImplementation(() => {
+                throw new Error();
+              }),
+            },
+          },
+        ],
       ].forEach(([scenario, badReq]) => {
         it(`passes an error if it cannot get the base URL (${scenario} scenario)`, () => {
           customFetchMiddleware(badReq, res, next);
-          sinon.assert.calledOnce(next);
-          expect(next.lastCall.firstArg).to.be.instanceof(Error);
+          expect(next).toHaveBeenCalledTimes(1);
+          expect(next.mock.calls.at(-1)[0]).toBeInstanceOf(Error);
         });
       });
     });
@@ -88,13 +97,12 @@ describe("custom-fetch.js with global.fetch mock", () => {
           method: "GET",
         });
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           { method: "GET", headers: {} },
         );
 
-        expect(response).to.equal(fetchResponse);
+        expect(response).toEqual(fetchResponse);
       });
 
       it("throws if a path is given without a leading slash", async () => {
@@ -103,12 +111,12 @@ describe("custom-fetch.js with global.fetch mock", () => {
         try {
           await dummyReq.customFetch("path/something/here");
         } catch (error) {
-          expect(error instanceof Error).to.equal(true);
-          expect(error.message).to.equal("Given path should start with '/'");
+          expect(error instanceof Error).toEqual(true);
+          expect(error.message).toEqual("Given path should start with '/'");
           errorThrown = true;
         }
 
-        expect(errorThrown).to.equal(true);
+        expect(errorThrown).toEqual(true);
       });
 
       it("logs the correct request information", async () => {
@@ -117,7 +125,8 @@ describe("custom-fetch.js with global.fetch mock", () => {
           timeoutMs: 10000,
         });
 
-        sinon.assert.calledWith(logInfo, "API request", {
+        const logInfo = loggerStub.info;
+        expect(logInfo).toHaveBeenCalledWith("API request", {
           config: {
             baseURL: "https://gov.uk",
             method: "GET",
@@ -133,8 +142,7 @@ describe("custom-fetch.js with global.fetch mock", () => {
           jsonBody: { hello: true, good: 1 },
         });
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           {
             method: "POST",
@@ -146,20 +154,19 @@ describe("custom-fetch.js with global.fetch mock", () => {
 
       it("correctly passes an AbortSignal to the fetch API", async () => {
         const fakeAbortSignal = { isAbortSignal: true };
-        const abortSignalMock = sinon
-          .stub(global.AbortSignal, "timeout")
-          .returns(fakeAbortSignal);
+        const abortSignalMock = vi
+          .spyOn(global.AbortSignal, "timeout")
+          .mockReturnValue(fakeAbortSignal);
 
         await dummyReq.customFetch("/path/something/here", {
           method: "GET",
           timeoutMs: 50,
         });
 
-        sinon.assert.calledOnce(abortSignalMock);
-        sinon.assert.calledWith(abortSignalMock, 50);
+        expect(abortSignalMock).toHaveBeenCalledTimes(1);
+        expect(abortSignalMock).toHaveBeenCalledWith(50);
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           {
             method: "GET",
@@ -167,31 +174,30 @@ describe("custom-fetch.js with global.fetch mock", () => {
             signal: fakeAbortSignal,
           },
         );
-
-        abortSignalMock.restore();
+        abortSignalMock.mockReset();
       });
 
       it("throws CustomFetchHttpError if the request fails", async () => {
         let didItThrow = false;
 
-        global.fetch.returns(badResponse);
+        global.fetch = vi.fn().mockResolvedValue(badResponse);
         try {
           await dummyReq.customFetch("/path/something/here", {
             method: "GET",
           });
         } catch (error) {
-          global.fetch.returns(fetchResponse);
+          global.fetch = vi.fn().mockResolvedValue(fetchResponse);
 
-          expect(error).to.be.an.instanceof(CustomFetchHttpError);
-          expect(error.code).to.equal(418);
-          expect(error.body).to.equal("no coffee for you");
-          expect(error.message).to.equal(`Response not OK: I'm a Teapot`);
-          expect(error.headers.get("some-header")).to.equal("illegal");
+          expect(error).toBeInstanceOf(CustomFetchHttpError);
+          expect(error.code).toEqual(418);
+          expect(error.body).toEqual("no coffee for you");
+          expect(error.message).toEqual(`Response not OK: I'm a Teapot`);
+          expect(error.headers.get("some-header")).toEqual("illegal");
 
           didItThrow = true;
         }
 
-        expect(didItThrow).to.equal(true);
+        expect(didItThrow).toEqual(true);
       });
     });
 
@@ -203,8 +209,7 @@ describe("custom-fetch.js with global.fetch mock", () => {
 
         await scenarioReq.customFetch("/path/something/here");
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           {
             headers: {
@@ -227,8 +232,7 @@ describe("custom-fetch.js with global.fetch mock", () => {
 
         await forwardedReq.customFetch("/path/something/here");
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           {
             headers: {
@@ -251,8 +255,7 @@ describe("custom-fetch.js with global.fetch mock", () => {
 
         await forwardedReq.customFetch("/path/something/here");
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           {
             headers: {
@@ -278,8 +281,7 @@ describe("custom-fetch.js with global.fetch mock", () => {
           headers: { "x-scenario-id": "no!", "x-forwarded-for": "bad!" },
         });
 
-        sinon.assert.calledWith(
-          global.fetch,
+        expect(global.fetch).toHaveBeenCalledWith(
           "https://gov.uk/path/something/here",
           {
             headers: {

--- a/src/lib/custom-fetch.test.js
+++ b/src/lib/custom-fetch.test.js
@@ -111,7 +111,7 @@ describe("custom-fetch.js with global.fetch mock", () => {
         try {
           await dummyReq.customFetch("path/something/here");
         } catch (error) {
-          expect(error instanceof Error).toEqual(true);
+          expect(error).toBeInstanceOf(Error);
           expect(error.message).toEqual("Given path should start with '/'");
           errorThrown = true;
         }

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -41,535 +41,539 @@ describe("error-handling", () => {
   });
 
   describe("redirectAsErrorToCallbackWithoutOauthPrefix", () => {
-    beforeEach(() => {
-      err = buildErrorWithBody({
-        redirect_uri: "http://error.example.org",
-        message: "Invalid request JWT",
-        code: "invalid_request_object",
+    describe("with HTTP errors", () => {
+      beforeEach(() => {
+        err = buildErrorWithBody({
+          redirect_uri: "http://error.example.org",
+          message: "Invalid request JWT",
+          code: "invalid_request_object",
+        });
       });
-    });
 
-    it("should override error values if provided in response body without Oauth Prefix", async () => {
-      await redirectAsErrorToCallback(err, req, res, next);
+      it("should override error values if provided in response body without Oauth Prefix", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: {
-            redirect_uri: "http://error.example.org",
-            error: {
-              code: "invalid_request_object",
-              description: "Invalid request JWT",
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+              error: {
+                code: "invalid_request_object",
+                description: "Invalid request JWT",
+              },
             },
-          },
-        }),
-      );
-    });
-
-    it("should use a default for error code", async () => {
-      err = buildErrorWithBody({
-        redirect_uri: "http://error.example.org",
-        message: "Invalid request JWT",
-        code: undefined,
+          }),
+        );
       });
 
-      await redirectAsErrorToCallback(err, req, res, next);
+      it("should use a default for error code", async () => {
+        err = buildErrorWithBody({
+          redirect_uri: "http://error.example.org",
+          message: "Invalid request JWT",
+          code: undefined,
+        });
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
-            error: expect.objectContaining({
-              code: "server_error",
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              error: expect.objectContaining({
+                code: "server_error",
+              }),
             }),
           }),
-        }),
-      );
-    });
-    it("should use a default for error description", async () => {
-      err = buildErrorWithBody({
-        redirect_uri: "http://error.example.org",
-        message: undefined,
-        code: "invalid_request_object",
+        );
       });
+      it("should use a default for error description", async () => {
+        err = buildErrorWithBody({
+          redirect_uri: "http://error.example.org",
+          message: undefined,
+          code: "invalid_request_object",
+        });
 
-      await redirectAsErrorToCallback(err, req, res, next);
+        await redirectAsErrorToCallback(err, req, res, next);
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
-            error: expect.objectContaining({
-              description: "general error",
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              error: expect.objectContaining({
+                description: "general error",
+              }),
             }),
           }),
-        }),
-      );
+        );
+      });
+      it("should use a default for redirect_uri", async () => {
+        err = buildErrorWithBody({
+          redirect_uri: undefined,
+          message: "Invalid request JWT",
+          code: "invalid_request_object",
+        });
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              redirect_uri: "http://example.org",
+            }),
+          }),
+        );
+      });
     });
-    it("should use a default for redirect_uri", async () => {
-      err = buildErrorWithBody({
-        redirect_uri: undefined,
-        message: "Invalid request JWT",
-        code: "invalid_request_object",
+
+    describe("with default Error object", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+
+        await redirectAsErrorToCallback(err, req, res, next);
       });
 
-      await redirectAsErrorToCallback(err, req, res, next);
-
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
+      it("should build redirect with default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith({
+          authParams: {
+            error: { code: "server_error", description: "general error" },
             redirect_uri: "http://example.org",
-          }),
-        }),
-      );
-    });
-  });
-
-  describe("with default Error object", () => {
-    beforeEach(async () => {
-      err = new Error("error message");
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should build redirect with default error code and description", () => {
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith({
-        authParams: {
-          error: { code: "server_error", description: "general error" },
-          redirect_uri: "http://example.org",
-        },
+          },
+        });
       });
     });
-  });
 
-  describe("with valid redirect url", () => {
-    beforeEach(async () => {
-      err = new Error("error message");
-      oAuthStub.buildRedirectUrl.mockReturnValue("http://example.org");
-      await redirectAsErrorToCallback(err, req, res, next);
+    describe("with valid redirect url", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+        oAuthStub.buildRedirectUrl.mockReturnValue("http://example.org");
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should call res.redirect with redirect_uri", () => {
+        expect(res.redirect).toHaveBeenCalledWith("http://example.org");
+      });
+
+      it("should not call next", () => {
+        expect(next).not.toHaveBeenCalled();
+      });
     });
 
-    it("should call res.redirect with redirect_uri", () => {
-      expect(res.redirect).toHaveBeenCalledWith("http://example.org");
-    });
+    describe("with invalid redirect url", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+        req.session.authParams.redirect_uri = "not-a-url";
+        oAuthStub.buildRedirectUrl.mockThrow("parse error");
 
-    it("should not call next", () => {
-      expect(next).not.toHaveBeenCalled();
-    });
-  });
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
 
-  describe("with invalid redirect url", () => {
-    beforeEach(async () => {
-      err = new Error("error message");
-      req.session.authParams.redirect_uri = "not-a-url";
-      oAuthStub.buildRedirectUrl.mockThrow("parse error");
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not call res.redirect", () => {
-      expect(res.redirect).not.toHaveBeenCalled();
-    });
-    it("should call next with err", () => {
-      expect(next).to.have.been.calledWith(err);
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.toHaveBeenCalled();
+      });
+      it("should call next with err", () => {
+        expect(next).to.have.been.calledWith(err);
+      });
     });
   });
 
   describe("redirectAsErrorToCallback", () => {
-    beforeEach(() => {
-      err = buildErrorWithBody({
-        redirect_uri: "http://error.example.org",
-        oauth_error: {
-          error_description: "Invalid request JWT",
-          error: "invalid_request_object",
-        },
+    describe("with HTTP errors", () => {
+      beforeEach(() => {
+        err = buildErrorWithBody({
+          redirect_uri: "http://error.example.org",
+          oauth_error: {
+            error_description: "Invalid request JWT",
+            error: "invalid_request_object",
+          },
+        });
+      });
+
+      it("should override error values if provided in response body", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+              error: {
+                code: "invalid_request_object",
+                description: "Invalid request JWT",
+              },
+            },
+          }),
+        );
+      });
+
+      it("should use a default for error code", async () => {
+        err = buildErrorWithBody({
+          redirect_uri: "http://error.example.org",
+          oauth_error: {
+            error_description: "Invalid request JWT",
+            error: undefined,
+          },
+        });
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              error: expect.objectContaining({
+                code: "server_error",
+              }),
+            }),
+          }),
+        );
+      });
+      it("should use a default for error description", async () => {
+        err = buildErrorWithBody({
+          redirect_uri: "http://error.example.org",
+          oauth_error: {
+            error_description: undefined,
+            error: "invalid_request_object",
+          },
+        });
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              error: expect.objectContaining({
+                description: "general error",
+              }),
+            }),
+          }),
+        );
+      });
+      it("should use a default for redirect_uri", async () => {
+        err = buildErrorWithBody({
+          redirect_uri: undefined,
+          oauth_error: {
+            error_description: "Invalid request JWT",
+            error: "invalid_request_object",
+          },
+        });
+
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              redirect_uri: "http://example.org",
+            }),
+          }),
+        );
       });
     });
 
-    it("should override error values if provided in response body", async () => {
-      await redirectAsErrorToCallback(err, req, res, next);
-
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: {
+    describe("with HTTP errors and no Content-Type header", () => {
+      beforeEach(() => {
+        err = buildErrorWithBody(
+          {
             redirect_uri: "http://error.example.org",
-            error: {
-              code: "invalid_request_object",
-              description: "Invalid request JWT",
+            oauth_error: {
+              error_description: "gateway",
+              error: "server_error",
             },
           },
-        }),
-      );
-    });
-
-    it("should use a default for error code", async () => {
-      err = buildErrorWithBody({
-        redirect_uri: "http://error.example.org",
-        oauth_error: {
-          error_description: "Invalid request JWT",
-          error: undefined,
-        },
+          null,
+        );
       });
 
-      await redirectAsErrorToCallback(err, req, res, next);
+      it("should still parse the body and override error values", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
-            error: expect.objectContaining({
-              code: "server_error",
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+              error: {
+                code: "server_error",
+                description: "gateway",
+              },
+            },
+          }),
+        );
+      });
+    });
+
+    describe("with HTTP errors and a Content-Type charset suffix", () => {
+      beforeEach(() => {
+        err = buildErrorWithBody(
+          {
+            redirect_uri: "http://error.example.org",
+            oauth_error: {
+              error_description: "gateway",
+              error: "server_error",
+            },
+          },
+          "application/json; charset=utf-8",
+        );
+      });
+
+      it("should still parse the body and override error values", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: {
+              redirect_uri: "http://error.example.org",
+              error: {
+                code: "server_error",
+                description: "gateway",
+              },
+            },
+          }),
+        );
+      });
+    });
+
+    describe("with an HTTP error body that is not valid JSON", () => {
+      let warn;
+
+      beforeEach(async () => {
+        warn = require("../bootstrap/lib/logger").get().warn;
+        warn.mockClear();
+
+        err = new CustomFetchHttpError(
+          {
+            status: 500,
+            statusText: "Internal Server Error",
+            ok: false,
+            headers: new Headers(),
+          },
+          "<html>not json</html>",
+        );
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should log a warning that the body could not be parsed", () => {
+        expect(warn).toHaveBeenCalledWith(
+          "Unable to parse HTTP response body as JSON",
+        );
+      });
+
+      it("should fall back to the default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              error: { code: "server_error", description: "general error" },
             }),
           }),
-        }),
-      );
+        );
+      });
     });
-    it("should use a default for error description", async () => {
-      err = buildErrorWithBody({
-        redirect_uri: "http://error.example.org",
-        oauth_error: {
-          error_description: undefined,
-          error: "invalid_request_object",
-        },
+
+    describe("with an HTTP error that has no body", () => {
+      let loggerStub;
+
+      beforeEach(async () => {
+        loggerStub = LOGGER_RESET();
+        err = new CustomFetchHttpError(
+          {
+            status: 500,
+            statusText: "Internal Server Error",
+            ok: false,
+            headers: new Headers(),
+          },
+          "",
+        );
+
+        await redirectAsErrorToCallback(err, req, res, next);
       });
 
-      await redirectAsErrorToCallback(err, req, res, next);
+      it("should not attempt to parse the body or log a warning", () => {
+        expect(loggerStub.warn).not.toHaveBeenCalled();
+      });
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
-            error: expect.objectContaining({
-              description: "general error",
+      it("should fall back to the default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authParams: expect.objectContaining({
+              error: { code: "server_error", description: "general error" },
             }),
           }),
-        }),
-      );
+        );
+      });
     });
-    it("should use a default for redirect_uri", async () => {
-      err = buildErrorWithBody({
-        redirect_uri: undefined,
-        oauth_error: {
-          error_description: "Invalid request JWT",
-          error: "invalid_request_object",
-        },
+
+    describe("with default Error object", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+
+        await redirectAsErrorToCallback(err, req, res, next);
       });
 
-      await redirectAsErrorToCallback(err, req, res, next);
-
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
+      it("should build redirect with default error code and description", () => {
+        expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith({
+          authParams: {
+            error: { code: "server_error", description: "general error" },
             redirect_uri: "http://example.org",
-          }),
-        }),
-      );
-    });
-  });
-
-  describe("with HTTP errors and no Content-Type header", () => {
-    beforeEach(() => {
-      err = buildErrorWithBody(
-        {
-          redirect_uri: "http://error.example.org",
-          oauth_error: {
-            error_description: "gateway",
-            error: "server_error",
           },
-        },
-        null,
-      );
+        });
+      });
     });
 
-    it("should still parse the body and override error values", async () => {
-      await redirectAsErrorToCallback(err, req, res, next);
+    describe("with valid redirect url", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+        oAuthStub.buildRedirectUrl.mockReturnValue("http://example.org");
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
+      it("should call res.redirect with redirect_uri", () => {
+        expect(res.redirect).toHaveBeenCalledWith("http://example.org");
+      });
+
+      it("should not call next", () => {
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("with invalid redirect url", () => {
+      beforeEach(async () => {
+        err = new Error("error message");
+        req.session.authParams.redirect_uri = "not-a-url";
+        oAuthStub.buildRedirectUrl.mockImplementation(() => {
+          throw new Error("parse error");
+        });
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.toHaveBeenCalled();
+      });
+      it("should call next with err", () => {
+        expect(next).toHaveBeenCalledWith(err);
+      });
+    });
+
+    describe("with a missing redirect_uri", () => {
+      beforeEach(async () => {
+        err = new Error("Missing redirect_uri");
+
+        req.session = {
+          authParams: undefined,
+        };
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.toHaveBeenCalled();
+      });
+
+      it("should call next with err", () => {
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing redirect_uri");
+      });
+    });
+
+    describe("with no redirect_uri but an existing session", () => {
+      beforeEach(async () => {
+        err = new Error("some other error");
+
+        req.session = {
+          tokenId: "some-token-id",
+          authParams: { redirect_uri: undefined, state: undefined },
+        };
+
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.toHaveBeenCalled();
+      });
+
+      it("should call next with a 'Missing redirect_uri' error", () => {
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing redirect_uri");
+      });
+    });
+
+    describe("with a missing redirect_uri, tokenId, and state", () => {
+      beforeEach(async () => {
+        req.session = {
           authParams: {
-            redirect_uri: "http://error.example.org",
-            error: {
-              code: "server_error",
-              description: "gateway",
-            },
+            redirect_uri: undefined,
+            state: undefined,
           },
-        }),
-      );
-    });
-  });
+          tokenId: undefined,
+        };
 
-  describe("with HTTP errors and a Content-Type charset suffix", () => {
-    beforeEach(() => {
-      err = buildErrorWithBody(
-        {
-          redirect_uri: "http://error.example.org",
-          oauth_error: {
-            error_description: "gateway",
-            error: "server_error",
-          },
-        },
-        "application/json; charset=utf-8",
-      );
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not call res.redirect", () => {
+        expect(res.redirect).not.toHaveBeenCalled();
+      });
+      it("should call next with err MISSING_AUTHPARAMS code", () => {
+        expect(next).toHaveBeenCalledWith(
+          expect.objectContaining({ code: "MISSING_AUTHPARAMS" }),
+        );
+      });
     });
 
-    it("should still parse the body and override error values", async () => {
-      await redirectAsErrorToCallback(err, req, res, next);
+    describe("with a static asset request", () => {
+      beforeEach(async () => {
+        err = new Error(
+          "Cannot read properties of undefined (reading 'language')",
+        );
+        req.path = "/public/govuk/govuk-frontend.min.js.map";
 
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
+        await redirectAsErrorToCallback(err, req, res, next);
+      });
+
+      it("should not redirect the asset request to the callback", () => {
+        expect(res.redirect).not.to.have.been.called;
+        expect(oAuthStub.buildRedirectUrl).not.to.have.been.called;
+      });
+
+      it("should pass the error through to next", () => {
+        expect(next).toHaveBeenCalledWith(err);
+      });
+    });
+
+    describe("MISSING_SESSION_DATA error", () => {
+      beforeEach(() => {
+        err = {
+          code: "MISSING_SESSION_DATA",
+          status: 401,
+        };
+      });
+      it("should call next with err MISSING_SESSION_DATA code", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(next).to.have.been.calledWith({
+          code: "MISSING_SESSION_DATA",
+          status: 401,
+        });
+      });
+      it("should not call res.redirect", async () => {
+        await redirectAsErrorToCallback(err, req, res, next);
+
+        expect(res.redirect).not.to.have.been.called;
+      });
+      it("should prioritise MISSING_SESSION_DATA before MISSING_AUTHPARAMS when error code explictly set in err ", async () => {
+        req.session = {
           authParams: {
-            redirect_uri: "http://error.example.org",
-            error: {
-              code: "server_error",
-              description: "gateway",
-            },
+            redirect_uri: undefined,
+            state: undefined,
           },
-        }),
-      );
-    });
-  });
+          tokenId: undefined,
+        };
 
-  describe("with an HTTP error body that is not valid JSON", () => {
-    let warn;
+        await redirectAsErrorToCallback(err, req, res, next);
 
-    beforeEach(async () => {
-      warn = require("../bootstrap/lib/logger").get().warn;
-      warn.mockClear();
-
-      err = new CustomFetchHttpError(
-        {
-          status: 500,
-          statusText: "Internal Server Error",
-          ok: false,
-          headers: new Headers(),
-        },
-        "<html>not json</html>",
-      );
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should log a warning that the body could not be parsed", () => {
-      expect(warn).toHaveBeenCalledWith(
-        "Unable to parse HTTP response body as JSON",
-      );
-    });
-
-    it("should fall back to the default error code and description", () => {
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
-            error: { code: "server_error", description: "general error" },
-          }),
-        }),
-      );
-    });
-  });
-
-  describe("with an HTTP error that has no body", () => {
-    let loggerStub;
-
-    beforeEach(async () => {
-      loggerStub = LOGGER_RESET();
-      err = new CustomFetchHttpError(
-        {
-          status: 500,
-          statusText: "Internal Server Error",
-          ok: false,
-          headers: new Headers(),
-        },
-        "",
-      );
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not attempt to parse the body or log a warning", () => {
-      expect(loggerStub.warn).not.toHaveBeenCalled();
-    });
-
-    it("should fall back to the default error code and description", () => {
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authParams: expect.objectContaining({
-            error: { code: "server_error", description: "general error" },
-          }),
-        }),
-      );
-    });
-  });
-
-  describe("with default Error object", () => {
-    beforeEach(async () => {
-      err = new Error("error message");
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should build redirect with default error code and description", () => {
-      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith({
-        authParams: {
-          error: { code: "server_error", description: "general error" },
-          redirect_uri: "http://example.org",
-        },
+        expect(next).to.have.been.calledWith({
+          code: "MISSING_SESSION_DATA",
+          status: 401,
+        });
+        expect(res.redirect).not.toHaveBeenCalled();
       });
-    });
-  });
-
-  describe("with valid redirect url", () => {
-    beforeEach(async () => {
-      err = new Error("error message");
-      oAuthStub.buildRedirectUrl.mockReturnValue("http://example.org");
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should call res.redirect with redirect_uri", () => {
-      expect(res.redirect).toHaveBeenCalledWith("http://example.org");
-    });
-
-    it("should not call next", () => {
-      expect(next).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("with invalid redirect url", () => {
-    beforeEach(async () => {
-      err = new Error("error message");
-      req.session.authParams.redirect_uri = "not-a-url";
-      oAuthStub.buildRedirectUrl.mockImplementation(() => {
-        throw new Error("parse error");
-      });
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not call res.redirect", () => {
-      expect(res.redirect).not.toHaveBeenCalled();
-    });
-    it("should call next with err", () => {
-      expect(next).toHaveBeenCalledWith(err);
-    });
-  });
-
-  describe("with a missing redirect_uri", () => {
-    beforeEach(async () => {
-      err = new Error("Missing redirect_uri");
-
-      req.session = {
-        authParams: undefined,
-      };
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not call res.redirect", () => {
-      expect(res.redirect).not.toHaveBeenCalled();
-    });
-
-    it("should call next with err", () => {
-      const err = next.mock.calls[0][0];
-      expect(err).toBeInstanceOf(Error);
-      expect(err.message).toBe("Missing redirect_uri");
-    });
-  });
-
-  describe("with no redirect_uri but an existing session", () => {
-    beforeEach(async () => {
-      err = new Error("some other error");
-
-      req.session = {
-        tokenId: "some-token-id",
-        authParams: { redirect_uri: undefined, state: undefined },
-      };
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not call res.redirect", () => {
-      expect(res.redirect).not.toHaveBeenCalled();
-    });
-
-    it("should call next with a 'Missing redirect_uri' error", () => {
-      const err = next.mock.calls[0][0];
-      expect(err).toBeInstanceOf(Error);
-      expect(err.message).toBe("Missing redirect_uri");
-    });
-  });
-
-  describe("with a missing redirect_uri, tokenId, and state", () => {
-    beforeEach(async () => {
-      req.session = {
-        authParams: {
-          redirect_uri: undefined,
-          state: undefined,
-        },
-        tokenId: undefined,
-      };
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not call res.redirect", () => {
-      expect(res.redirect).not.toHaveBeenCalled();
-    });
-    it("should call next with err MISSING_AUTHPARAMS code", () => {
-      expect(next).toHaveBeenCalledWith(
-        expect.objectContaining({ code: "MISSING_AUTHPARAMS" }),
-      );
-    });
-  });
-
-  describe("with a static asset request", () => {
-    beforeEach(async () => {
-      err = new Error(
-        "Cannot read properties of undefined (reading 'language')",
-      );
-      req.path = "/public/govuk/govuk-frontend.min.js.map";
-
-      await redirectAsErrorToCallback(err, req, res, next);
-    });
-
-    it("should not redirect the asset request to the callback", () => {
-      expect(res.redirect).not.to.have.been.called;
-      expect(oAuthStub.buildRedirectUrl).not.to.have.been.called;
-    });
-
-    it("should pass the error through to next", () => {
-      expect(next).toHaveBeenCalledWith(err);
-    });
-  });
-
-  describe("MISSING_SESSION_DATA error", () => {
-    beforeEach(() => {
-      err = {
-        code: "MISSING_SESSION_DATA",
-        status: 401,
-      };
-    });
-    it("should call next with err MISSING_SESSION_DATA code", async () => {
-      await redirectAsErrorToCallback(err, req, res, next);
-
-      expect(next).to.have.been.calledWith({
-        code: "MISSING_SESSION_DATA",
-        status: 401,
-      });
-    });
-    it("should not call res.redirect", async () => {
-      await redirectAsErrorToCallback(err, req, res, next);
-
-      expect(res.redirect).not.to.have.been.called;
-    });
-    it("should prioritise MISSING_SESSION_DATA before MISSING_AUTHPARAMS when error code explictly set in err ", async () => {
-      req.session = {
-        authParams: {
-          redirect_uri: undefined,
-          state: undefined,
-        },
-        tokenId: undefined,
-      };
-
-      await redirectAsErrorToCallback(err, req, res, next);
-
-      expect(next).to.have.been.calledWith({
-        code: "MISSING_SESSION_DATA",
-        status: 401,
-      });
-      expect(res.redirect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/error-handling.test.js
+++ b/src/lib/error-handling.test.js
@@ -1,3 +1,6 @@
+import { describe, vi, expect, beforeEach, it } from "vitest";
+import { createDefaultReqResNext } from "../../test/utils/helpers";
+
 const proxyquire = require("proxyquire");
 const { CustomFetchHttpError } = require("./custom-fetch");
 
@@ -25,7 +28,7 @@ describe("error-handling", () => {
   let err;
 
   beforeEach(() => {
-    const setup = setupDefaultMocks();
+    const setup = createDefaultReqResNext();
     req = setup.req;
     res = setup.res;
     next = setup.next;
@@ -34,547 +37,539 @@ describe("error-handling", () => {
       authParams: { redirect_uri: "http://example.org" },
     };
 
-    oAuthStub.buildRedirectUrl = sinon.stub();
+    oAuthStub.buildRedirectUrl = vi.fn();
   });
 
   describe("redirectAsErrorToCallbackWithoutOauthPrefix", () => {
-    context("with HTTP errors", () => {
-      beforeEach(() => {
-        err = buildErrorWithBody({
-          redirect_uri: "http://error.example.org",
-          message: "Invalid request JWT",
-          code: "invalid_request_object",
-        });
-      });
-
-      it("should override error values if provided in response body without Oauth Prefix", async () => {
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              redirect_uri: "http://error.example.org",
-              error: {
-                code: "invalid_request_object",
-                description: "Invalid request JWT",
-              },
-            },
-          }),
-        );
-      });
-
-      it("should use a default for error code", async () => {
-        err = buildErrorWithBody({
-          redirect_uri: "http://error.example.org",
-          message: "Invalid request JWT",
-          code: undefined,
-        });
-
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              error: {
-                code: "server_error",
-              },
-            },
-          }),
-        );
-      });
-      it("should use a default for error description", async () => {
-        err = buildErrorWithBody({
-          redirect_uri: "http://error.example.org",
-          message: undefined,
-          code: "invalid_request_object",
-        });
-
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              error: {
-                description: "general error",
-              },
-            },
-          }),
-        );
-      });
-      it("should use a default for redirect_uri", async () => {
-        err = buildErrorWithBody({
-          redirect_uri: undefined,
-          message: "Invalid request JWT",
-          code: "invalid_request_object",
-        });
-
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              redirect_uri: "http://example.org",
-            },
-          }),
-        );
+    beforeEach(() => {
+      err = buildErrorWithBody({
+        redirect_uri: "http://error.example.org",
+        message: "Invalid request JWT",
+        code: "invalid_request_object",
       });
     });
 
-    context("with default Error object", () => {
-      beforeEach(async () => {
-        err = new Error("error message");
+    it("should override error values if provided in response body without Oauth Prefix", async () => {
+      await redirectAsErrorToCallback(err, req, res, next);
 
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should build redirect with default error code and description", () => {
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith({
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
           authParams: {
-            error: { code: "server_error", description: "general error" },
-            redirect_uri: "http://example.org",
+            redirect_uri: "http://error.example.org",
+            error: {
+              code: "invalid_request_object",
+              description: "Invalid request JWT",
+            },
           },
-        });
-      });
+        }),
+      );
     });
 
-    context("with valid redirect url", () => {
-      beforeEach(async () => {
-        err = new Error("error message");
-        oAuthStub.buildRedirectUrl.returns("http://example.org");
-        await redirectAsErrorToCallback(err, req, res, next);
+    it("should use a default for error code", async () => {
+      err = buildErrorWithBody({
+        redirect_uri: "http://error.example.org",
+        message: "Invalid request JWT",
+        code: undefined,
       });
 
-      it("should call res.redirect with redirect_uri", () => {
-        expect(res.redirect).to.have.been.calledWith("http://example.org");
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            error: expect.objectContaining({
+              code: "server_error",
+            }),
+          }),
+        }),
+      );
+    });
+    it("should use a default for error description", async () => {
+      err = buildErrorWithBody({
+        redirect_uri: "http://error.example.org",
+        message: undefined,
+        code: "invalid_request_object",
       });
 
-      it("should not call next", () => {
-        expect(next).not.to.have.been.called;
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            error: expect.objectContaining({
+              description: "general error",
+            }),
+          }),
+        }),
+      );
+    });
+    it("should use a default for redirect_uri", async () => {
+      err = buildErrorWithBody({
+        redirect_uri: undefined,
+        message: "Invalid request JWT",
+        code: "invalid_request_object",
       });
+
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            redirect_uri: "http://example.org",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("with default Error object", () => {
+    beforeEach(async () => {
+      err = new Error("error message");
+
+      await redirectAsErrorToCallback(err, req, res, next);
     });
 
-    context("with invalid redirect url", () => {
-      beforeEach(async () => {
-        err = new Error("error message");
-        req.session.authParams.redirect_uri = "not-a-url";
-        oAuthStub.buildRedirectUrl.throws("parse error");
+    it("should build redirect with default error code and description", () => {
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith({
+        authParams: {
+          error: { code: "server_error", description: "general error" },
+          redirect_uri: "http://example.org",
+        },
+      });
+    });
+  });
 
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
+  describe("with valid redirect url", () => {
+    beforeEach(async () => {
+      err = new Error("error message");
+      oAuthStub.buildRedirectUrl.mockReturnValue("http://example.org");
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
 
-      it("should not call res.redirect", () => {
-        expect(res.redirect).not.to.have.been.called;
-      });
-      it("should call next with err", () => {
-        expect(next).to.have.been.calledWith(err);
-      });
+    it("should call res.redirect with redirect_uri", () => {
+      expect(res.redirect).toHaveBeenCalledWith("http://example.org");
+    });
+
+    it("should not call next", () => {
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("with invalid redirect url", () => {
+    beforeEach(async () => {
+      err = new Error("error message");
+      req.session.authParams.redirect_uri = "not-a-url";
+      oAuthStub.buildRedirectUrl.mockThrow("parse error");
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not call res.redirect", () => {
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+    it("should call next with err", () => {
+      expect(next).to.have.been.calledWith(err);
     });
   });
 
   describe("redirectAsErrorToCallback", () => {
-    context("with HTTP errors", () => {
-      beforeEach(() => {
-        err = buildErrorWithBody({
-          redirect_uri: "http://error.example.org",
-          oauth_error: {
-            error_description: "Invalid request JWT",
-            error: "invalid_request_object",
-          },
-        });
-      });
-
-      it("should override error values if provided in response body", async () => {
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              redirect_uri: "http://error.example.org",
-              error: {
-                code: "invalid_request_object",
-                description: "Invalid request JWT",
-              },
-            },
-          }),
-        );
-      });
-
-      it("should use a default for error code", async () => {
-        err = buildErrorWithBody({
-          redirect_uri: "http://error.example.org",
-          oauth_error: {
-            error_description: "Invalid request JWT",
-            error: undefined,
-          },
-        });
-
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              error: {
-                code: "server_error",
-              },
-            },
-          }),
-        );
-      });
-      it("should use a default for error description", async () => {
-        err = buildErrorWithBody({
-          redirect_uri: "http://error.example.org",
-          oauth_error: {
-            error_description: undefined,
-            error: "invalid_request_object",
-          },
-        });
-
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              error: {
-                description: "general error",
-              },
-            },
-          }),
-        );
-      });
-      it("should use a default for redirect_uri", async () => {
-        err = buildErrorWithBody({
-          redirect_uri: undefined,
-          oauth_error: {
-            error_description: "Invalid request JWT",
-            error: "invalid_request_object",
-          },
-        });
-
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              redirect_uri: "http://example.org",
-            },
-          }),
-        );
+    beforeEach(() => {
+      err = buildErrorWithBody({
+        redirect_uri: "http://error.example.org",
+        oauth_error: {
+          error_description: "Invalid request JWT",
+          error: "invalid_request_object",
+        },
       });
     });
 
-    context("with HTTP errors and no Content-Type header", () => {
-      beforeEach(() => {
-        err = buildErrorWithBody(
-          {
-            redirect_uri: "http://error.example.org",
-            oauth_error: {
-              error_description: "gateway",
-              error: "server_error",
-            },
-          },
-          null,
-        );
-      });
+    it("should override error values if provided in response body", async () => {
+      await redirectAsErrorToCallback(err, req, res, next);
 
-      it("should still parse the body and override error values", async () => {
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              redirect_uri: "http://error.example.org",
-              error: {
-                code: "server_error",
-                description: "gateway",
-              },
-            },
-          }),
-        );
-      });
-    });
-
-    context("with HTTP errors and a Content-Type charset suffix", () => {
-      beforeEach(() => {
-        err = buildErrorWithBody(
-          {
-            redirect_uri: "http://error.example.org",
-            oauth_error: {
-              error_description: "gateway",
-              error: "server_error",
-            },
-          },
-          "application/json; charset=utf-8",
-        );
-      });
-
-      it("should still parse the body and override error values", async () => {
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              redirect_uri: "http://error.example.org",
-              error: {
-                code: "server_error",
-                description: "gateway",
-              },
-            },
-          }),
-        );
-      });
-    });
-
-    context("with an HTTP error body that is not valid JSON", () => {
-      let warn;
-
-      beforeEach(async () => {
-        warn = require("../bootstrap/lib/logger").get().warn;
-        warn.resetHistory();
-
-        err = new CustomFetchHttpError(
-          {
-            status: 500,
-            statusText: "Internal Server Error",
-            ok: false,
-            headers: new Headers(),
-          },
-          "<html>not json</html>",
-        );
-
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should log a warning that the body could not be parsed", () => {
-        expect(warn).to.have.been.calledWith(
-          "Unable to parse HTTP response body as JSON",
-        );
-      });
-
-      it("should fall back to the default error code and description", () => {
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              error: { code: "server_error", description: "general error" },
-            },
-          }),
-        );
-      });
-    });
-
-    context("with an HTTP error that has no body", () => {
-      let warn;
-
-      beforeEach(async () => {
-        warn = require("../bootstrap/lib/logger").get().warn;
-        warn.resetHistory();
-
-        err = new CustomFetchHttpError(
-          {
-            status: 500,
-            statusText: "Internal Server Error",
-            ok: false,
-            headers: new Headers(),
-          },
-          "",
-        );
-
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should not attempt to parse the body or log a warning", () => {
-        expect(warn).not.to.have.been.called;
-      });
-
-      it("should fall back to the default error code and description", () => {
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith(
-          sinon.match({
-            authParams: {
-              error: { code: "server_error", description: "general error" },
-            },
-          }),
-        );
-      });
-    });
-
-    context("with default Error object", () => {
-      beforeEach(async () => {
-        err = new Error("error message");
-
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should build redirect with default error code and description", () => {
-        expect(oAuthStub.buildRedirectUrl).to.have.been.calledWith({
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
           authParams: {
-            error: { code: "server_error", description: "general error" },
+            redirect_uri: "http://error.example.org",
+            error: {
+              code: "invalid_request_object",
+              description: "Invalid request JWT",
+            },
+          },
+        }),
+      );
+    });
+
+    it("should use a default for error code", async () => {
+      err = buildErrorWithBody({
+        redirect_uri: "http://error.example.org",
+        oauth_error: {
+          error_description: "Invalid request JWT",
+          error: undefined,
+        },
+      });
+
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            error: expect.objectContaining({
+              code: "server_error",
+            }),
+          }),
+        }),
+      );
+    });
+    it("should use a default for error description", async () => {
+      err = buildErrorWithBody({
+        redirect_uri: "http://error.example.org",
+        oauth_error: {
+          error_description: undefined,
+          error: "invalid_request_object",
+        },
+      });
+
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            error: expect.objectContaining({
+              description: "general error",
+            }),
+          }),
+        }),
+      );
+    });
+    it("should use a default for redirect_uri", async () => {
+      err = buildErrorWithBody({
+        redirect_uri: undefined,
+        oauth_error: {
+          error_description: "Invalid request JWT",
+          error: "invalid_request_object",
+        },
+      });
+
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
             redirect_uri: "http://example.org",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("with HTTP errors and no Content-Type header", () => {
+    beforeEach(() => {
+      err = buildErrorWithBody(
+        {
+          redirect_uri: "http://error.example.org",
+          oauth_error: {
+            error_description: "gateway",
+            error: "server_error",
           },
-        });
-      });
+        },
+        null,
+      );
     });
 
-    context("with valid redirect url", () => {
-      beforeEach(async () => {
-        err = new Error("error message");
-        oAuthStub.buildRedirectUrl.returns("http://example.org");
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
+    it("should still parse the body and override error values", async () => {
+      await redirectAsErrorToCallback(err, req, res, next);
 
-      it("should call res.redirect with redirect_uri", () => {
-        expect(res.redirect).to.have.been.calledWith("http://example.org");
-      });
-
-      it("should not call next", () => {
-        expect(next).not.to.have.been.called;
-      });
-    });
-
-    context("with invalid redirect url", () => {
-      beforeEach(async () => {
-        err = new Error("error message");
-        req.session.authParams.redirect_uri = "not-a-url";
-        oAuthStub.buildRedirectUrl.throws("parse error");
-
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should not call res.redirect", () => {
-        expect(res.redirect).not.to.have.been.called;
-      });
-      it("should call next with err", () => {
-        expect(next).to.have.been.calledWith(err);
-      });
-    });
-
-    context("with a missing redirect_uri", () => {
-      beforeEach(async () => {
-        err = new Error("Missing redirect_uri");
-
-        req.session = {
-          authParams: undefined,
-        };
-
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should not call res.redirect", () => {
-        expect(res.redirect).not.to.have.been.called;
-      });
-
-      it("should call next with err", () => {
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing redirect_uri")),
-        );
-      });
-    });
-
-    context("with no redirect_uri but an existing session", () => {
-      beforeEach(async () => {
-        err = new Error("some other error");
-
-        req.session = {
-          tokenId: "some-token-id",
-          authParams: { redirect_uri: undefined, state: undefined },
-        };
-
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should not call res.redirect", () => {
-        expect(res.redirect).not.to.have.been.called;
-      });
-
-      it("should call next with a 'Missing redirect_uri' error", () => {
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing redirect_uri")),
-        );
-      });
-    });
-
-    context("with a missing redirect_uri, tokenId, and state", () => {
-      beforeEach(async () => {
-        req.session = {
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
           authParams: {
-            redirect_uri: undefined,
-            state: undefined,
+            redirect_uri: "http://error.example.org",
+            error: {
+              code: "server_error",
+              description: "gateway",
+            },
           },
-          tokenId: undefined,
-        };
+        }),
+      );
+    });
+  });
 
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should not call res.redirect", () => {
-        expect(res.redirect).not.to.have.been.called;
-      });
-      it("should call next with err MISSING_AUTHPARAMS code", () => {
-        expect(next).to.have.been.calledWith(
-          sinon.match.has("code", "MISSING_AUTHPARAMS"),
-        );
-      });
+  describe("with HTTP errors and a Content-Type charset suffix", () => {
+    beforeEach(() => {
+      err = buildErrorWithBody(
+        {
+          redirect_uri: "http://error.example.org",
+          oauth_error: {
+            error_description: "gateway",
+            error: "server_error",
+          },
+        },
+        "application/json; charset=utf-8",
+      );
     });
 
-    context("with a static asset request", () => {
-      beforeEach(async () => {
-        err = new Error(
-          "Cannot read properties of undefined (reading 'language')",
-        );
-        req.path = "/public/govuk/govuk-frontend.min.js.map";
+    it("should still parse the body and override error values", async () => {
+      await redirectAsErrorToCallback(err, req, res, next);
 
-        await redirectAsErrorToCallback(err, req, res, next);
-      });
-
-      it("should not redirect the asset request to the callback", () => {
-        expect(res.redirect).not.to.have.been.called;
-        expect(oAuthStub.buildRedirectUrl).not.to.have.been.called;
-      });
-
-      it("should pass the error through to next", () => {
-        expect(next).to.have.been.calledWith(err);
-      });
-    });
-
-    context("MISSING_SESSION_DATA error", () => {
-      beforeEach(() => {
-        err = {
-          code: "MISSING_SESSION_DATA",
-          status: 401,
-        };
-      });
-      it("should call next with err MISSING_SESSION_DATA code", async () => {
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(next).to.have.been.calledWith({
-          code: "MISSING_SESSION_DATA",
-          status: 401,
-        });
-      });
-      it("should not call res.redirect", async () => {
-        await redirectAsErrorToCallback(err, req, res, next);
-
-        expect(res.redirect).not.to.have.been.called;
-      });
-      it("should prioritise MISSING_SESSION_DATA before MISSING_AUTHPARAMS when error code explictly set in err ", async () => {
-        req.session = {
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
           authParams: {
-            redirect_uri: undefined,
-            state: undefined,
+            redirect_uri: "http://error.example.org",
+            error: {
+              code: "server_error",
+              description: "gateway",
+            },
           },
-          tokenId: undefined,
-        };
+        }),
+      );
+    });
+  });
 
-        await redirectAsErrorToCallback(err, req, res, next);
+  describe("with an HTTP error body that is not valid JSON", () => {
+    let warn;
 
-        expect(next).to.have.been.calledWith({
-          code: "MISSING_SESSION_DATA",
-          status: 401,
-        });
-        expect(res.redirect).not.to.have.been.called;
+    beforeEach(async () => {
+      warn = require("../bootstrap/lib/logger").get().warn;
+      warn.mockClear();
+
+      err = new CustomFetchHttpError(
+        {
+          status: 500,
+          statusText: "Internal Server Error",
+          ok: false,
+          headers: new Headers(),
+        },
+        "<html>not json</html>",
+      );
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should log a warning that the body could not be parsed", () => {
+      expect(warn).toHaveBeenCalledWith(
+        "Unable to parse HTTP response body as JSON",
+      );
+    });
+
+    it("should fall back to the default error code and description", () => {
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            error: { code: "server_error", description: "general error" },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("with an HTTP error that has no body", () => {
+    let loggerStub;
+
+    beforeEach(async () => {
+      loggerStub = LOGGER_RESET();
+      err = new CustomFetchHttpError(
+        {
+          status: 500,
+          statusText: "Internal Server Error",
+          ok: false,
+          headers: new Headers(),
+        },
+        "",
+      );
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not attempt to parse the body or log a warning", () => {
+      expect(loggerStub.warn).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to the default error code and description", () => {
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authParams: expect.objectContaining({
+            error: { code: "server_error", description: "general error" },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("with default Error object", () => {
+    beforeEach(async () => {
+      err = new Error("error message");
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should build redirect with default error code and description", () => {
+      expect(oAuthStub.buildRedirectUrl).toHaveBeenCalledWith({
+        authParams: {
+          error: { code: "server_error", description: "general error" },
+          redirect_uri: "http://example.org",
+        },
       });
+    });
+  });
+
+  describe("with valid redirect url", () => {
+    beforeEach(async () => {
+      err = new Error("error message");
+      oAuthStub.buildRedirectUrl.mockReturnValue("http://example.org");
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should call res.redirect with redirect_uri", () => {
+      expect(res.redirect).toHaveBeenCalledWith("http://example.org");
+    });
+
+    it("should not call next", () => {
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("with invalid redirect url", () => {
+    beforeEach(async () => {
+      err = new Error("error message");
+      req.session.authParams.redirect_uri = "not-a-url";
+      oAuthStub.buildRedirectUrl.mockImplementation(() => {
+        throw new Error("parse error");
+      });
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not call res.redirect", () => {
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+    it("should call next with err", () => {
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe("with a missing redirect_uri", () => {
+    beforeEach(async () => {
+      err = new Error("Missing redirect_uri");
+
+      req.session = {
+        authParams: undefined,
+      };
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not call res.redirect", () => {
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+
+    it("should call next with err", () => {
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Missing redirect_uri");
+    });
+  });
+
+  describe("with no redirect_uri but an existing session", () => {
+    beforeEach(async () => {
+      err = new Error("some other error");
+
+      req.session = {
+        tokenId: "some-token-id",
+        authParams: { redirect_uri: undefined, state: undefined },
+      };
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not call res.redirect", () => {
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+
+    it("should call next with a 'Missing redirect_uri' error", () => {
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Missing redirect_uri");
+    });
+  });
+
+  describe("with a missing redirect_uri, tokenId, and state", () => {
+    beforeEach(async () => {
+      req.session = {
+        authParams: {
+          redirect_uri: undefined,
+          state: undefined,
+        },
+        tokenId: undefined,
+      };
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not call res.redirect", () => {
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+    it("should call next with err MISSING_AUTHPARAMS code", () => {
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "MISSING_AUTHPARAMS" }),
+      );
+    });
+  });
+
+  describe("with a static asset request", () => {
+    beforeEach(async () => {
+      err = new Error(
+        "Cannot read properties of undefined (reading 'language')",
+      );
+      req.path = "/public/govuk/govuk-frontend.min.js.map";
+
+      await redirectAsErrorToCallback(err, req, res, next);
+    });
+
+    it("should not redirect the asset request to the callback", () => {
+      expect(res.redirect).not.to.have.been.called;
+      expect(oAuthStub.buildRedirectUrl).not.to.have.been.called;
+    });
+
+    it("should pass the error through to next", () => {
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+  describe("MISSING_SESSION_DATA error", () => {
+    beforeEach(() => {
+      err = {
+        code: "MISSING_SESSION_DATA",
+        status: 401,
+      };
+    });
+    it("should call next with err MISSING_SESSION_DATA code", async () => {
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(next).to.have.been.calledWith({
+        code: "MISSING_SESSION_DATA",
+        status: 401,
+      });
+    });
+    it("should not call res.redirect", async () => {
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(res.redirect).not.to.have.been.called;
+    });
+    it("should prioritise MISSING_SESSION_DATA before MISSING_AUTHPARAMS when error code explictly set in err ", async () => {
+      req.session = {
+        authParams: {
+          redirect_uri: undefined,
+          state: undefined,
+        },
+        tokenId: undefined,
+      };
+
+      await redirectAsErrorToCallback(err, req, res, next);
+
+      expect(next).to.have.been.calledWith({
+        code: "MISSING_SESSION_DATA",
+        status: 401,
+      });
+      expect(res.redirect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/headers.test.js
+++ b/src/lib/headers.test.js
@@ -1,3 +1,6 @@
+import { expect, it, describe, beforeEach } from "vitest";
+import { createDefaultReqResNext } from "../../test/utils/helpers";
+
 const headers = require("./headers");
 
 describe("headers", () => {
@@ -6,7 +9,7 @@ describe("headers", () => {
   let next;
 
   beforeEach(() => {
-    const setup = setupDefaultMocks();
+    const setup = createDefaultReqResNext();
     req = setup.req;
     req["x-forwarded-proto"] = "http";
 
@@ -17,10 +20,10 @@ describe("headers", () => {
   });
 
   it("should set 'x-forwarded-proto' as 'https'", () => {
-    expect(req.headers["x-forwarded-proto"]).to.equal("https");
+    expect(req.headers["x-forwarded-proto"]).toEqual("https");
   });
 
   it("should call next", () => {
-    expect(next).to.have.been.called;
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/src/lib/i18next/configure.test.js
+++ b/src/lib/i18next/configure.test.js
@@ -1,44 +1,42 @@
+import { describe, it, expect } from "vitest";
+
 const { configure } = require("./configure");
 const defaultConfig = require("./default-config");
 
 describe("configure", () => {
-  context("with no arguments", () => {
-    it("should return default config", () => {
-      let config = configure();
+  it("should return default config", () => {
+    let config = configure();
 
-      expect(config).to.deep.equal({ debug: false, ...defaultConfig });
+    expect(config).toEqual({ debug: false, ...defaultConfig });
+  });
+
+  it("should return config with overwridden properties", () => {
+    let { detection, debug, ...configWithoutDetection } = configure({
+      secure: true,
+      cookieDomain: "localhost",
+      debug: true,
+    });
+
+    expect(defaultConfig).toMatchObject(configWithoutDetection);
+
+    expect(debug).toBe(true);
+
+    expect(detection).toEqual({
+      ...defaultConfig.detection,
+      cookieSecure: true,
+      cookieDomain: "localhost",
     });
   });
 
-  context("with arguments", () => {
-    it("should return config with overwridden properties", () => {
-      let { detection, debug, ...configWithoutDetection } = configure({
-        secure: true,
-        cookieDomain: "localhost",
-        debug: true,
-      });
+  it("should merge additionalNamespaces into ns", () => {
+    const config = configure({ additionalNamespaces: ["frontend-ui"] });
 
-      expect(defaultConfig).to.deep.include(configWithoutDetection);
+    expect(config.ns).toEqual([...defaultConfig.ns, "frontend-ui"]);
+  });
 
-      expect(debug).to.be.true;
+  it("should not modify ns when additionalNamespaces is empty", () => {
+    const config = configure({ additionalNamespaces: [] });
 
-      expect(detection).to.deep.equal({
-        ...defaultConfig.detection,
-        cookieSecure: true,
-        cookieDomain: "localhost",
-      });
-    });
-
-    it("should merge additionalNamespaces into ns", () => {
-      const config = configure({ additionalNamespaces: ["frontend-ui"] });
-
-      expect(config.ns).to.deep.equal([...defaultConfig.ns, "frontend-ui"]);
-    });
-
-    it("should not modify ns when additionalNamespaces is empty", () => {
-      const config = configure({ additionalNamespaces: [] });
-
-      expect(config.ns).to.deep.equal(defaultConfig.ns);
-    });
+    expect(config.ns).toEqual(defaultConfig.ns);
   });
 });

--- a/src/lib/i18next/handler.test.js
+++ b/src/lib/i18next/handler.test.js
@@ -1,3 +1,5 @@
+import { it, expect, beforeEach, vi, describe } from "vitest";
+
 const proxyquire = require("proxyquire").noCallThru();
 
 let handler;
@@ -12,20 +14,20 @@ defaultConfig = {
 };
 
 i18next = {
-  use: sinon.stub().returnsThis(),
-  init: sinon.stub(),
+  use: vi.fn().mockReturnThis(),
+  init: vi.fn(),
 };
 
 i18NextHttpMiddleware = {
   LanguageDetector: "LanguageDetector",
-  handle: sinon.stub().returns("instantiated handler"),
+  handle: vi.fn().mockReturnValue("instantiated handler"),
 };
 
 configure = {
-  configure: sinon.stub().returns(defaultConfig),
+  configure: vi.fn().mockReturnValueOnce(defaultConfig),
 };
 
-i18NextFsBackend = sinon.stub();
+i18NextFsBackend = vi.fn();
 
 handler = proxyquire("./handler", {
   i18next,
@@ -35,26 +37,21 @@ handler = proxyquire("./handler", {
 });
 describe("handler", () => {
   beforeEach(() => {
-    i18next.init.reset();
-    configure.configure.reset();
+    i18next.init.mockReset();
+    configure.configure.mockReset();
 
-    configure.configure.returns(defaultConfig);
+    configure.configure.mockReturnValueOnce(defaultConfig);
   });
 
   it("should call i18next.use with backend", () => {
     handler.handler();
-
-    const firstUse = i18next.use.getCall(0);
-
-    expect(firstUse).to.have.been.calledWith(i18NextFsBackend);
+    expect(i18next.use).toHaveBeenNthCalledWith(1, i18NextFsBackend);
   });
 
   it("should call i18next.use with language detector", () => {
     handler.handler();
-
-    const firstUse = i18next.use.getCall(1);
-
-    expect(firstUse).to.have.been.calledWith(
+    expect(i18next.use).toHaveBeenNthCalledWith(
+      2,
       i18NextHttpMiddleware.LanguageDetector,
     );
   });
@@ -62,7 +59,7 @@ describe("handler", () => {
   it("should call init with config", () => {
     handler.handler();
 
-    expect(i18next.init).to.have.been.calledWithExactly(defaultConfig);
+    expect(i18next.init).toHaveBeenCalledWith(defaultConfig);
   });
 
   it("should call configure with config from params", () => {
@@ -72,7 +69,7 @@ describe("handler", () => {
       cookieDomain: "subdomain.local",
     });
 
-    expect(configure.configure).to.have.been.calledWithExactly({
+    expect(configure.configure).toHaveBeenCalledWith({
       debug: true,
       secure: true,
       cookieDomain: "subdomain.local",
@@ -83,16 +80,16 @@ describe("handler", () => {
   it("should thread additionalNamespaces through to configure", () => {
     handler.handler({ additionalNamespaces: ["frontend-ui"] });
 
-    expect(configure.configure).to.have.been.calledWithExactly(
-      sinon.match({ additionalNamespaces: ["frontend-ui"] }),
+    expect(configure.configure).toHaveBeenCalledWith(
+      expect.objectContaining({ additionalNamespaces: ["frontend-ui"] }),
     );
   });
 
   it("should call onInit with i18next after init", () => {
-    const onInit = sinon.stub();
+    const onInit = vi.fn();
     handler.handler({ onInit });
 
-    expect(onInit).to.have.been.calledWithExactly(i18next);
+    expect(onInit).toHaveBeenCalledWith(i18next);
     expect(onInit).to.have.been.calledAfter(i18next.init);
   });
 
@@ -105,13 +102,13 @@ describe("handler", () => {
       cookieDomain: "subdomain.local",
     });
 
-    expect(i18next.init).to.have.been.calledWithExactly(defaultConfig);
+    expect(i18next.init).toHaveBeenCalledWith(defaultConfig);
   });
 
   it("should call i18nextMiddleware.handle with options", () => {
     handler.handler();
 
-    expect(i18NextHttpMiddleware.handle).to.have.been.calledWith(i18next, {
+    expect(i18NextHttpMiddleware.handle).toHaveBeenCalledWith(i18next, {
       ignoreRoutes: ["/public"],
     });
   });
@@ -119,6 +116,6 @@ describe("handler", () => {
   it("should return i18nextMiddleware handler", () => {
     let instantiatedHandler = handler.handler();
 
-    expect(instantiatedHandler).to.equal("instantiated handler");
+    expect(instantiatedHandler).toEqual("instantiated handler");
   });
 });

--- a/src/lib/i18next/index.test.js
+++ b/src/lib/i18next/index.test.js
@@ -1,6 +1,8 @@
+import { describe, it, vi, beforeEach, expect } from "vitest";
+
 const proxyquire = require("proxyquire");
-const handler = sinon.stub().returns("handler function");
-const replaceTranslate = sinon.stub();
+const handler = vi.fn().mockReturnValueOnce("handler function");
+const replaceTranslate = vi.fn();
 
 const { setI18n, i18next } = proxyquire("./", {
   "./handler": {
@@ -16,19 +18,17 @@ describe("i18next", () => {
   let config;
 
   beforeEach(() => {
-    router = { use: sinon.stub() };
+    router = { use: vi.fn() };
     config = { debug: true, secure: false, cookieDomain: "sub.domain.local" };
 
     setI18n({ router, config });
   });
 
   it("should use handler", () => {
-    const handlerCall = router.use.getCall(0);
-
-    expect(handlerCall).to.have.been.calledWithExactly("handler function");
+    expect(router.use).toHaveBeenNthCalledWith(1, "handler function");
   });
   it("should call handler", () => {
-    expect(handler).to.have.been.calledWithExactly({
+    expect(handler).toHaveBeenCalledWith({
       debug: true,
       secure: false,
       cookieDomain: "sub.domain.local",
@@ -37,32 +37,30 @@ describe("i18next", () => {
     });
   });
   it("should use replaceTranslate", () => {
-    const replaceCall = router.use.getCall(1);
-
-    expect(replaceCall).to.have.been.calledWithExactly(replaceTranslate);
+    expect(router.use).toHaveBeenNthCalledWith(2, replaceTranslate);
   });
 
   it("should pass additionalNamespaces through to handler", () => {
-    handler.resetHistory();
+    handler.mockClear();
     setI18n({
       router,
       config: { ...config, additionalNamespaces: ["frontend-ui"] },
     });
 
-    expect(handler).to.have.been.calledWithExactly(
-      sinon.match({ additionalNamespaces: ["frontend-ui"] }),
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ additionalNamespaces: ["frontend-ui"] }),
     );
   });
 
   it("should pass onInit through to handler", () => {
-    handler.resetHistory();
-    const onInit = sinon.stub();
+    handler.mockClear();
+    const onInit = vi.fn();
     setI18n({ router, config, onInit });
 
-    expect(handler).to.have.been.calledWithExactly(sinon.match({ onInit }));
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ onInit }));
   });
 
   it("should export the i18next singleton", () => {
-    expect(i18next).to.equal(require("i18next"));
+    expect(i18next).toEqual(require("i18next"));
   });
 });

--- a/src/lib/i18next/replace-translate.test.js
+++ b/src/lib/i18next/replace-translate.test.js
@@ -1,3 +1,6 @@
+import { expect, describe, it, beforeEach, vi } from "vitest";
+import { createDefaultReqResNext } from "../../../test/utils/helpers";
+
 const proxyquire = require("proxyquire");
 
 describe("replaceTranslate", () => {
@@ -8,7 +11,7 @@ describe("replaceTranslate", () => {
   let replaceTranslate;
 
   beforeEach(() => {
-    const setup = setupDefaultMocks();
+    const setup = createDefaultReqResNext();
     req = setup.req;
     res = setup.res;
     next = setup.next;
@@ -16,14 +19,14 @@ describe("replaceTranslate", () => {
     req.translate = undefined;
 
     req.i18n = {
-      getFixedT: sinon.stub(),
+      getFixedT: vi.fn(),
       language: "en",
     };
 
-    warn = sinon.stub();
+    warn = vi.fn();
     ({ replaceTranslate } = proxyquire("./replace-translate", {
       "../../bootstrap/lib/logger": {
-        get: sinon.stub().returns({ warn }),
+        get: vi.fn().mockReturnValueOnce({ warn }),
       },
     }));
   });
@@ -31,89 +34,87 @@ describe("replaceTranslate", () => {
   it("should call getFixedT with language", () => {
     replaceTranslate(req, res, next);
 
-    expect(req.i18n.getFixedT).to.have.been.calledWithExactly(
-      req.i18n.language,
-    );
+    expect(req.i18n.getFixedT).toHaveBeenCalledWith(req.i18n.language);
   });
 
   it("should replace translate with getFixedT function", () => {
-    const translate = sinon.fake();
-    req.i18n.getFixedT.returns(translate);
+    const translate = vi.fn();
+    req.i18n.getFixedT.mockReturnValueOnce(translate);
     replaceTranslate(req, res, next);
 
-    expect(req.translate).to.equal(translate);
+    expect(req.translate).toEqual(translate);
   });
 
   it("should set res.locals.translate as a function", () => {
     replaceTranslate(req, res, next);
 
-    expect(res.locals.translate).to.be.a("function");
+    expect(typeof res.locals.translate).toBe("function");
   });
 
   it("should call translate with res.locals spread as interpolation context", () => {
-    const translate = sinon.stub();
-    req.i18n.getFixedT.returns(translate);
+    const translate = vi.fn();
+    req.i18n.getFixedT.mockReturnValueOnce(translate);
     res.locals.favFood = "Sausage";
 
     replaceTranslate(req, res, next);
     res.locals.translate("some.key");
 
-    expect(translate).to.have.been.calledWithExactly(
+    expect(translate).toHaveBeenCalledWith(
       "some.key",
-      sinon.match({ favFood: "Sausage" }),
+      expect.objectContaining({ favFood: "Sausage" }),
     );
   });
 
   it("should allow opts to override res.locals in interpolation context", () => {
-    const translate = sinon.stub();
-    req.i18n.getFixedT.returns(translate);
+    const translate = vi.fn();
+    req.i18n.getFixedT.mockReturnValueOnce(translate);
     res.locals.favFood = "Sausage";
 
     replaceTranslate(req, res, next);
     res.locals.translate("some.key", { favFood: "Saucisson" });
 
-    expect(translate).to.have.been.calledWithExactly(
+    expect(translate).toHaveBeenCalledWith(
       "some.key",
-      sinon.match({ favFood: "Saucisson" }),
+      expect.objectContaining({ favFood: "Saucisson" }),
     );
   });
 
   it("should not overwrite an existing res.locals.translate", () => {
-    const existing = sinon.fake();
+    const existing = vi.fn();
     res.locals.translate = existing;
 
     replaceTranslate(req, res, next);
 
-    expect(res.locals.translate).to.equal(existing);
+    expect(res.locals.translate).toEqual(existing);
   });
 
   it("should warn when res.locals.translate is already set", () => {
-    res.locals.translate = sinon.fake();
+    res.locals.translate = vi.fn();
 
     replaceTranslate(req, res, next);
 
-    expect(warn).to.have.been.calledOnce;
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it("should only warn once across multiple requests", () => {
-    res.locals.translate = sinon.fake();
+    res.locals.translate = vi.fn();
 
     replaceTranslate(req, res, next);
     replaceTranslate(req, res, next);
     replaceTranslate(req, res, next);
 
-    expect(warn).to.have.been.calledOnce;
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it("should not warn when res.locals.translate is unset", () => {
     replaceTranslate(req, res, next);
 
-    expect(warn).to.not.have.been.called;
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("should call next", () => {
     replaceTranslate(req, res, next);
 
-    expect(next).to.have.been.calledWithExactly();
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/src/lib/oauth.test.js
+++ b/src/lib/oauth.test.js
@@ -1,3 +1,5 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
 const { addOAuthPropertiesToSession, buildRedirectUrl } = require("./oauth");
 
 describe("oauth lib", () => {
@@ -15,7 +17,7 @@ describe("oauth lib", () => {
 
       addOAuthPropertiesToSession({ authParams, data });
 
-      expect(authParams.redirect_uri).to.equal(data.redirect_uri);
+      expect(authParams.redirect_uri).toEqual(data.redirect_uri);
     });
 
     it("should save 'state' to sessionModel", () => {
@@ -23,7 +25,7 @@ describe("oauth lib", () => {
 
       addOAuthPropertiesToSession({ authParams, data });
 
-      expect(authParams.state).to.equal(data.state);
+      expect(authParams.state).toEqual(data.state);
     });
 
     describe("with authorization_code", () => {
@@ -32,7 +34,7 @@ describe("oauth lib", () => {
 
         addOAuthPropertiesToSession({ authParams, data });
 
-        expect(authParams.authorization_code).to.equal(data.code);
+        expect(authParams.authorization_code).toEqual(data.code);
       });
     });
 
@@ -40,7 +42,7 @@ describe("oauth lib", () => {
       it("should save 'error' to sessionModel", () => {
         addOAuthPropertiesToSession({ authParams, data });
 
-        expect(authParams.error).to.deep.equal({
+        expect(authParams.error).toEqual({
           code: "server_error",
           error_description: "Failed to retrieve authorization code",
         });
@@ -70,7 +72,7 @@ describe("oauth lib", () => {
       buildRedirectUrl({ authParams });
     });
 
-    context("with an authorization_code", () => {
+    describe("with an authorization_code", () => {
       beforeEach(() => {
         authParams = {
           redirect_uri: "http://example.org",
@@ -83,23 +85,21 @@ describe("oauth lib", () => {
       it("should add authorization_code", () => {
         redirectUrl = buildRedirectUrl({ authParams });
 
-        expect(redirectUrl.searchParams.get("code")).to.equal(
+        expect(redirectUrl.searchParams.get("code")).toEqual(
           authParams.authorization_code,
         );
       });
       it("should add client_id", () => {
         redirectUrl = buildRedirectUrl({ authParams });
 
-        expect(redirectUrl.searchParams.get("client_id")).to.equal(
+        expect(redirectUrl.searchParams.get("client_id")).toEqual(
           authParams.client_id,
         );
       });
       it("should add state if available", () => {
         redirectUrl = buildRedirectUrl({ authParams });
 
-        expect(redirectUrl.searchParams.get("state")).to.equal(
-          authParams.state,
-        );
+        expect(redirectUrl.searchParams.get("state")).toEqual(authParams.state);
       });
 
       it("should not add state if not available", () => {
@@ -107,60 +107,57 @@ describe("oauth lib", () => {
 
         redirectUrl = buildRedirectUrl({ authParams });
 
-        expect(redirectUrl.searchParams.get("state")).to.be.null;
+        expect(redirectUrl.searchParams.get("state")).toBeNull();
       });
     });
 
-    context("without an authorization_code", () => {
-      describe("with an error object", () => {
-        let error;
-        beforeEach(() => {
-          error = {
-            code: "E_ERROR",
-            message: "Error Message",
-            description: "Error Description",
-          };
+    describe("with an error object", () => {
+      let error;
+      beforeEach(() => {
+        error = {
+          code: "E_ERROR",
+          message: "Error Message",
+          description: "Error Description",
+        };
 
-          authParams = {
-            redirect_uri: "http://example.org",
-            error,
-          };
-        });
-
-        it("should add the error code", () => {
-          redirectUrl = buildRedirectUrl({ authParams });
-
-          expect(redirectUrl.searchParams.get("error")).to.equal(error.code);
-        });
-        it("should add the error description if available", () => {
-          redirectUrl = buildRedirectUrl({ authParams });
-
-          expect(redirectUrl.searchParams.get("error_description")).to.equal(
-            error.description,
-          );
-        });
-        it("should add the error message as a fallback", () => {
-          delete error.description;
-          redirectUrl = buildRedirectUrl({ authParams });
-
-          expect(redirectUrl.searchParams.get("error_description")).to.equal(
-            error.message,
-          );
-        });
-        it("should add state if available", () => {
-          redirectUrl = buildRedirectUrl({
-            authParams: { state: "state-prop", ...authParams },
-          });
-
-          expect(redirectUrl.searchParams.get("state")).to.equal("state-prop");
-        });
-        it("should not add state if not available", () => {
-          redirectUrl = buildRedirectUrl({ authParams });
-
-          expect(redirectUrl.searchParams.get("state")).to.be.null;
-        });
+        authParams = {
+          redirect_uri: "http://example.org",
+          error,
+        };
       });
-      describe("without an error object", () => {});
+
+      it("should add the error code", () => {
+        redirectUrl = buildRedirectUrl({ authParams });
+
+        expect(redirectUrl.searchParams.get("error")).toEqual(error.code);
+      });
+      it("should add the error description if available", () => {
+        redirectUrl = buildRedirectUrl({ authParams });
+
+        expect(redirectUrl.searchParams.get("error_description")).toEqual(
+          error.description,
+        );
+      });
+      it("should add the error message as a fallback", () => {
+        delete error.description;
+        redirectUrl = buildRedirectUrl({ authParams });
+
+        expect(redirectUrl.searchParams.get("error_description")).toEqual(
+          error.message,
+        );
+      });
+      it("should add state if available", () => {
+        redirectUrl = buildRedirectUrl({
+          authParams: { state: "state-prop", ...authParams },
+        });
+
+        expect(redirectUrl.searchParams.get("state")).toEqual("state-prop");
+      });
+      it("should not add state if not available", () => {
+        redirectUrl = buildRedirectUrl({ authParams });
+
+        expect(redirectUrl.searchParams.get("state")).toBeNull();
+      });
     });
   });
 });

--- a/src/lib/oauth.test.js
+++ b/src/lib/oauth.test.js
@@ -113,7 +113,7 @@ describe("oauth lib", () => {
       });
     });
 
-    describe("with an error object", () => {
+    describe("without an authorization_code with an error object", () => {
       let error;
       beforeEach(() => {
         error = {

--- a/src/lib/oauth.test.js
+++ b/src/lib/oauth.test.js
@@ -69,7 +69,9 @@ describe("oauth lib", () => {
         redirect_uri: "http://example.org",
       };
 
-      buildRedirectUrl({ authParams });
+      const result = buildRedirectUrl({ authParams });
+      expect(result).toBeInstanceOf(URL);
+      expect(result.origin).toBe("http://example.org");
     });
 
     describe("with an authorization_code", () => {

--- a/src/lib/redis.test.js
+++ b/src/lib/redis.test.js
@@ -10,7 +10,7 @@ describe("redis", () => {
     });
   });
 
-  it("should return empty config", () => {
+  it("should return empty config when no environment variables are given", () => {
     const redisConfig = redis();
 
     expect(redisConfig).toEqual({});

--- a/src/lib/redis.test.js
+++ b/src/lib/redis.test.js
@@ -1,21 +1,18 @@
+import { expect, describe, it } from "vitest";
 describe("redis", () => {
   const redis = require("./redis");
 
-  context("with environment variables", () => {
-    it("should return config using environment variables", () => {
-      const redisConfig = redis({ SESSION_URL: "example.org", PORT: "4321" });
+  it("should return config using environment variables", () => {
+    const redisConfig = redis({ SESSION_URL: "example.org", PORT: "4321" });
 
-      expect(redisConfig).to.include({
-        connectionString: "redis://example.org:4321",
-      });
+    expect(redisConfig).toMatchObject({
+      connectionString: "redis://example.org:4321",
     });
   });
 
-  context("without environment variables", () => {
-    it("should return empty config", () => {
-      const redisConfig = redis();
+  it("should return empty config", () => {
+    const redisConfig = redis();
 
-      expect(redisConfig).to.deep.equal({});
-    });
+    expect(redisConfig).toEqual({});
   });
 });

--- a/src/lib/scenario-headers.test.js
+++ b/src/lib/scenario-headers.test.js
@@ -1,3 +1,6 @@
+import { describe, expect, beforeEach, it } from "vitest";
+import { createDefaultReqResNext } from "../../test/utils/helpers";
+
 const scenarioHeaders = require("./scenario-headers");
 
 describe("scenario-headers", () => {
@@ -6,13 +9,13 @@ describe("scenario-headers", () => {
   let next;
 
   beforeEach(() => {
-    const setup = setupDefaultMocks();
+    const setup = createDefaultReqResNext();
     req = setup.req;
     res = setup.res;
     next = setup.next;
   });
 
-  context("with 'NODE_ENV' as 'development'", () => {
+  describe("with 'NODE_ENV' as 'development'", () => {
     beforeEach(() => {
       process.env.NODE_ENV = "development";
       req.headers["x-scenario-id"] = "scenario-number-1";
@@ -20,15 +23,15 @@ describe("scenario-headers", () => {
     });
 
     it("should set scenarioHeader on req", () => {
-      expect(req.scenarioIDHeader).to.equal("scenario-number-1");
+      expect(req.scenarioIDHeader).toEqual("scenario-number-1");
     });
 
     it("should call next", () => {
-      expect(next).to.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
   });
 
-  context("with 'NODE_ENV' not as 'development'", () => {
+  describe("with 'NODE_ENV' not as 'development'", () => {
     beforeEach(() => {
       process.env.NODE_ENV = "production";
       req.headers["x-scenario-id"] = "scenario-number-1";
@@ -36,26 +39,26 @@ describe("scenario-headers", () => {
     });
 
     it("should not set scenarioHeader on req", () => {
-      expect(req.scenarioIDHeader).to.be.undefined;
+      expect(req.scenarioIDHeader).toBeUndefined();
     });
 
     it("should call next", () => {
-      expect(next).to.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
   });
 
-  context('with missing "x-scenario-id" header', () => {
+  describe('with missing "x-scenario-id" header', () => {
     beforeEach(() => {
       process.env.NODE_ENV = "development";
       scenarioHeaders(req, res, next);
     });
 
     it("should not set scenarioHeader on req", () => {
-      expect(req.scenarioIDHeader).to.be.undefined;
+      expect(req.scenarioIDHeader).toBeUndefined();
     });
 
     it("should call next", () => {
-      expect(next).to.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/user-ip-address.test.js
+++ b/src/lib/user-ip-address.test.js
@@ -1,57 +1,54 @@
+import { expect, describe, it } from "vitest";
+
 const userIpAddress = require("./user-ip-address");
 
 describe("user ip address", () => {
-  context("without ip header", () => {
-    it("should return null when passing req but with req.headers as null", () => {
-      const forwarded = null;
-      const ipAddress = userIpAddress(forwarded);
+  it("should return null when passing req but with req.headers as null", () => {
+    const forwarded = null;
+    const ipAddress = userIpAddress(forwarded);
 
-      expect(ipAddress).to.equal(null);
-    });
+    expect(ipAddress).toEqual(null);
   });
 
-  context("with ip header", () => {
-    it("should return Ip Address in forwarded header", () => {
-      const forwarded =
-        "for=192.0.2.0;host=subdomain.example.gov.uk;proto=https";
+  it("should return Ip Address in forwarded header", () => {
+    const forwarded = "for=192.0.2.0;host=subdomain.example.gov.uk;proto=https";
 
-      const ipAddress = userIpAddress(forwarded);
+    const ipAddress = userIpAddress(forwarded);
 
-      expect(ipAddress).to.equal("192.0.2.0");
-    });
+    expect(ipAddress).toEqual("192.0.2.0");
+  });
 
-    it("should return forwarded header with ipV4 address", () => {
-      const forwarded =
-        "host=subdomain.example.gov.uk;for=  192.0.2.0  ;proto=https";
+  it("should return forwarded header with ipV4 address", () => {
+    const forwarded =
+      "host=subdomain.example.gov.uk;for=  192.0.2.0  ;proto=https";
 
-      const ipAddress = userIpAddress(forwarded);
+    const ipAddress = userIpAddress(forwarded);
 
-      expect(ipAddress).to.equal("192.0.2.0");
-    });
+    expect(ipAddress).toEqual("192.0.2.0");
+  });
 
-    it("should return forwarded header with ipV6 address", () => {
-      const forwarded =
-        "host=subdomain.example.gov.uk;for=2001:db8:3333:4444:5555:6666:7777:8888;proto=https";
+  it("should return forwarded header with ipV6 address", () => {
+    const forwarded =
+      "host=subdomain.example.gov.uk;for=2001:db8:3333:4444:5555:6666:7777:8888;proto=https";
 
-      const ipAddress = userIpAddress(forwarded);
+    const ipAddress = userIpAddress(forwarded);
 
-      expect(ipAddress).to.equal("2001:db8:3333:4444:5555:6666:7777:8888");
-    });
+    expect(ipAddress).toEqual("2001:db8:3333:4444:5555:6666:7777:8888");
+  });
 
-    it("should return null address when we have no for iteam", () => {
-      const forwarded = "host=subdomain.example.gov.uk;proto=https";
+  it("should return null address when we have no for iteam", () => {
+    const forwarded = "host=subdomain.example.gov.uk;proto=https";
 
-      const ipAddress = userIpAddress(forwarded);
+    const ipAddress = userIpAddress(forwarded);
 
-      expect(ipAddress).to.equal(null);
-    });
+    expect(ipAddress).toEqual(null);
+  });
 
-    it("should return null address when we have empty ip address in for item", () => {
-      const forwarded = "host=subdomain.example.gov.uk;for=;proto=https";
+  it("should return null address when we have empty ip address in for item", () => {
+    const forwarded = "host=subdomain.example.gov.uk;for=;proto=https";
 
-      const ipAddress = userIpAddress(forwarded);
+    const ipAddress = userIpAddress(forwarded);
 
-      expect(ipAddress).to.equal(null);
-    });
+    expect(ipAddress).toEqual(null);
   });
 });

--- a/src/lib/user-ip-address.test.js
+++ b/src/lib/user-ip-address.test.js
@@ -7,7 +7,7 @@ describe("user ip address", () => {
     const forwarded = null;
     const ipAddress = userIpAddress(forwarded);
 
-    expect(ipAddress).toEqual(null);
+    expect(ipAddress).toBeNull();
   });
 
   it("should return Ip Address in forwarded header", () => {
@@ -41,7 +41,7 @@ describe("user ip address", () => {
 
     const ipAddress = userIpAddress(forwarded);
 
-    expect(ipAddress).toEqual(null);
+    expect(ipAddress).toBeNull();
   });
 
   it("should return null address when we have empty ip address in for item", () => {
@@ -49,6 +49,6 @@ describe("user ip address", () => {
 
     const ipAddress = userIpAddress(forwarded);
 
-    expect(ipAddress).toEqual(null);
+    expect(ipAddress).toBeNull();
   });
 });

--- a/src/lib/user-ip-address.test.js
+++ b/src/lib/user-ip-address.test.js
@@ -10,30 +10,27 @@ describe("user ip address", () => {
     expect(ipAddress).toBeNull();
   });
 
-  it("should return Ip Address in forwarded header", () => {
-    const forwarded = "for=192.0.2.0;host=subdomain.example.gov.uk;proto=https";
-
+  it.each([
+    {
+      description: "should return Ip Address in forwarded header",
+      forwarded: "for=192.0.2.0;host=subdomain.example.gov.uk;proto=https",
+      expected: "192.0.2.0",
+    },
+    {
+      description: "should return forwarded header with ipV4 address",
+      forwarded: "host=subdomain.example.gov.uk;for=  192.0.2.0  ;proto=https",
+      expected: "192.0.2.0",
+    },
+    {
+      description: "should return forwarded header with ipV6 address",
+      forwarded:
+        "host=subdomain.example.gov.uk;for=2001:db8:3333:4444:5555:6666:7777:8888;proto=https",
+      expected: "2001:db8:3333:4444:5555:6666:7777:8888",
+    },
+  ])("$description", ({ forwarded, expected }) => {
     const ipAddress = userIpAddress(forwarded);
 
-    expect(ipAddress).toEqual("192.0.2.0");
-  });
-
-  it("should return forwarded header with ipV4 address", () => {
-    const forwarded =
-      "host=subdomain.example.gov.uk;for=  192.0.2.0  ;proto=https";
-
-    const ipAddress = userIpAddress(forwarded);
-
-    expect(ipAddress).toEqual("192.0.2.0");
-  });
-
-  it("should return forwarded header with ipV6 address", () => {
-    const forwarded =
-      "host=subdomain.example.gov.uk;for=2001:db8:3333:4444:5555:6666:7777:8888;proto=https";
-
-    const ipAddress = userIpAddress(forwarded);
-
-    expect(ipAddress).toEqual("2001:db8:3333:4444:5555:6666:7777:8888");
+    expect(ipAddress).toEqual(expected);
   });
 
   it("should return null address when we have no for iteam", () => {

--- a/src/routes/oauth2/middleware.test.js
+++ b/src/routes/oauth2/middleware.test.js
@@ -1,3 +1,5 @@
+import { describe, vi, it, expect, beforeEach, afterEach } from "vitest";
+
 const middleware = require("./middleware");
 
 const exampleJwt =
@@ -5,22 +7,22 @@ const exampleJwt =
 
 const buildMocks = () => ({
   req: {
-    customFetch: sinon.fake(),
-    app: { get: sinon.stub() },
+    customFetch: vi.fn(),
+    app: { get: vi.fn() },
     session: {},
     headers: {},
     body: {},
     query: {},
     ip: "127.0.0.1",
   },
-  res: { redirect: sinon.spy() },
-  next: sinon.fake(),
+  res: { redirect: vi.fn() },
+  next: vi.fn(),
 });
 
 function buildResponseWithBody(body, statusCode) {
   return {
     statusCode: statusCode ?? 200,
-    json: sinon.stub().resolves(body),
+    json: vi.fn().mockResolvedValue(body),
   };
 }
 
@@ -37,7 +39,7 @@ describe("oauth middleware", () => {
   });
 
   afterEach(() => {
-    require("../../bootstrap/lib/logger").get().error.resetHistory();
+    require("../../bootstrap/lib/logger").get().error.mockClear();
   });
 
   describe("addAuthParamsToSession", () => {
@@ -54,7 +56,7 @@ describe("oauth middleware", () => {
     it("should save authParams to session", async function () {
       await middleware.addAuthParamsToSession(req, res, next);
 
-      expect(req.session.authParams).to.deep.equal({
+      expect(req.session.authParams).toEqual({
         client_id: req.query.client_id,
       });
     });
@@ -62,7 +64,7 @@ describe("oauth middleware", () => {
     it("should call next", async function () {
       await middleware.addAuthParamsToSession(req, res, next);
 
-      expect(next).to.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
   });
 
@@ -76,15 +78,15 @@ describe("oauth middleware", () => {
     });
 
     it("should save authParams to session", async function () {
-      await middleware.addJWTToRequest(req, res, next);
+      middleware.addJWTToRequest(req, res, next);
 
-      expect(req.jwt).to.equal(req.query.request);
+      expect(req.jwt).toEqual(req.query.request);
     });
 
     it("should call next", async function () {
-      await middleware.addJWTToRequest(req, res, next);
+      middleware.addJWTToRequest(req, res, next);
 
-      expect(next).to.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
   });
 
@@ -107,17 +109,16 @@ describe("oauth middleware", () => {
       });
     });
 
-    context("with missing properties", () => {
+    describe("with missing properties", () => {
       it("should call next with an error when req.jwt is missing", async () => {
         delete req.jwt;
 
         await middleware.initSessionWithJWT(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing JWT")),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing JWT");
       });
 
       it("should call next with an error when req.session.authParams is missing", async () => {
@@ -125,41 +126,40 @@ describe("oauth middleware", () => {
 
         await middleware.initSessionWithJWT(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing client_id")),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing client_id");
       });
 
       it("should call next with an error when API.PATHS.SESSION is missing", async () => {
         await middleware.initSessionWithJWT(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing API.PATHS.SESSION value")),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing API.PATHS.SESSION value");
       });
     });
 
-    context("on authorization request", () => {
+    describe("on authorization request", () => {
       beforeEach(() => {
         req.app = {
-          get: sinon.stub(),
+          get: vi.fn(),
         };
-        req.app.get.withArgs("API.PATHS.SESSION").returns("/api/authorize");
-        req.app.get.withArgs("API.BASE_URL").returns("http://localhost:3000");
-
+        req.app.get.mockImplementation((arg) => {
+          if (arg === "API.PATHS.SESSION") return "/api/authorize";
+          if (arg === "API.BASE_URL") return "http://localhost:3000";
+        });
         req.headers = {
           "txma-audit-encoded": "dummy-txma-header",
           "x-forwarded-for": "198.51.100.10:46532",
         };
       });
-
       it("should call the authorize endpoint with the correct parameters", async function () {
         await middleware.initSessionWithJWT(req, res, next);
-        expect(req.customFetch).to.have.been.calledWith("/api/authorize", {
+
+        expect(req.customFetch).toHaveBeenCalledWith("/api/authorize", {
           method: "POST",
           headers: {
             "txma-audit-encoded": "dummy-txma-header",
@@ -172,7 +172,7 @@ describe("oauth middleware", () => {
         });
       });
 
-      context("with API result", () => {
+      describe("with API result", () => {
         beforeEach(async () => {
           response = buildResponseWithBody({
             session_id: "abc1234",
@@ -180,46 +180,49 @@ describe("oauth middleware", () => {
             redirect_uri: "http://example.org:9001/callback",
             govuk_signin_journey_id: "test-journey-id",
           });
-          req.customFetch = sinon.fake.returns(response);
+          req.customFetch = vi.fn().mockReturnValue(response);
 
           await middleware.initSessionWithJWT(req, res, next);
         });
 
         it("should save 'session_id' into req.session", () => {
-          expect(req.session.tokenId).to.equal("abc1234");
+          expect(req.session.tokenId).toEqual("abc1234");
         });
 
         it("should save 'state' into req.session.authParams", () => {
-          expect(req.session.authParams.state).to.equal("rAnd0m-i5ed_STring");
+          expect(req.session.authParams.state).toEqual("rAnd0m-i5ed_STring");
         });
 
         it("should save 'redirect_uri' into req.session.authParams", () => {
-          expect(req.session.authParams.redirect_uri).to.equal(
+          expect(req.session.authParams.redirect_uri).toEqual(
             "http://example.org:9001/callback",
           );
         });
         it("should save 'govuk_signin_journey_id' into req.session", () => {
-          expect(req.session.govuk_signin_journey_id).to.equal(
+          expect(req.session.govuk_signin_journey_id).toEqual(
             "test-journey-id",
           );
         });
         it("should call next", function () {
-          expect(next).to.have.been.called;
+          expect(next).toHaveBeenCalled();
         });
       });
 
-      context("with API error", () => {
+      describe("with API error", () => {
         beforeEach(async () => {
-          req.customFetch = sinon.fake.throws(new Error("API error"));
+          req.customFetch = vi.fn(() => {
+            throw new Error("API error");
+          });
 
           await middleware.initSessionWithJWT(req, res, next);
         });
 
         it("should call next with error", () => {
-          expect(next).to.have.been.calledWith(
-            sinon.match
-              .instanceOf(Error)
-              .and(sinon.match.has("message", "API error")),
+          expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+          expect(next).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: "API error",
+            }),
           );
         });
       });
@@ -231,7 +234,7 @@ describe("oauth middleware", () => {
 
     beforeEach(() => {
       req.app = {
-        get: sinon.stub(),
+        get: vi.fn(),
       };
 
       req.session = {
@@ -250,17 +253,16 @@ describe("oauth middleware", () => {
       });
     });
 
-    context("with missing properties", () => {
+    describe("with missing properties", () => {
       it("should call next with an error when req.session.tokenId is missing", async () => {
         delete req.session.tokenId;
 
         await middleware.retrieveAuthorizationCode(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing session-id")),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing session-id");
       });
 
       it("should call next with an error when req.session.authParams.client_id is missing", async () => {
@@ -268,11 +270,10 @@ describe("oauth middleware", () => {
 
         await middleware.retrieveAuthorizationCode(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing client_id")),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing client_id");
       });
 
       it("should call next with an error when req.session.authParams.redirect_uri is missing", async () => {
@@ -280,37 +281,29 @@ describe("oauth middleware", () => {
 
         await middleware.retrieveAuthorizationCode(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(sinon.match.has("message", "Missing redirect_uri")),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing redirect_uri");
       });
 
       it("should call next with an error when API.PATHS.AUTHORIZATION is missing", async () => {
         await middleware.retrieveAuthorizationCode(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(
-              sinon.match.has(
-                "message",
-                "Missing API.PATHS.AUTHORIZATION value",
-              ),
-            ),
-        );
+        expect(next).toHaveBeenCalled();
+        const err = next.mock.calls[0][0];
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toBe("Missing API.PATHS.AUTHORIZATION value");
       });
     });
 
-    context("on authorization request", () => {
+    describe("on authorization request", () => {
       beforeEach(() => {
-        req.app.get
-          .withArgs("API.PATHS.AUTHORIZATION")
-          .returns("/api/authorize");
-        req.app.get.withArgs("API.PATHS.SESSION").returns("/api/authorize");
-        req.app.get.withArgs("API.BASE_URL").returns("http://localhost:3000");
-
+        req.app.get.mockImplementation((arg) => {
+          if (arg === "API.PATHS.AUTHORIZATION") return "/api/authorize";
+          if (arg === "API.PATHS.SESSION") return "/api/authorize";
+          if (arg === "API.BASE_URL") return "http://localhost:3000";
+        });
         req.headers = {
           "txma-audit-encoded": "dummy-txma-header",
           "x-forwarded-for": "198.51.100.10:46532",
@@ -320,7 +313,7 @@ describe("oauth middleware", () => {
       it("should call the auth code endpoint with the correct parameters", async function () {
         await middleware.retrieveAuthorizationCode(req, res, next);
 
-        expect(req.customFetch).to.have.been.calledWith(
+        expect(req.customFetch).toHaveBeenCalledWith(
           "/api/authorize?client_id=test_client&state=sT%40t3&redirect_uri=http%3A%2F%2Fexample.net%2F&response_type=code&scope=openid",
           {
             headers: {
@@ -333,35 +326,36 @@ describe("oauth middleware", () => {
         );
       });
 
-      context("with API result", () => {
+      describe("with API result", () => {
         beforeEach(async () => {
-          req.customFetch = sinon.fake.returns(response);
+          req.customFetch = vi.fn().mockReturnValue(response);
 
           await middleware.retrieveAuthorizationCode(req, res, next);
         });
 
         it("should save 'authorization_code' into req.session.authParams", () => {
-          expect(req.session.authParams.authorization_code).to.equal("auth000");
+          expect(req.session.authParams.authorization_code).toEqual("auth000");
         });
 
         it("should call next", function () {
-          expect(next).to.have.been.calledWith();
+          expect(next).toHaveBeenCalledWith();
         });
       });
 
-      context("with API error", () => {
+      describe("with API error", () => {
         beforeEach(async () => {
-          req.customFetch = sinon.fake.throws(new Error("API error"));
+          req.customFetch = vi.fn(() => {
+            throw new Error("API error");
+          });
 
           await middleware.retrieveAuthorizationCode(req, res, next);
         });
 
         it("should call next with error", () => {
-          expect(next).to.have.been.calledWith(
-            sinon.match
-              .instanceOf(Error)
-              .and(sinon.match.has("message", "API error")),
-          );
+          expect(next).toHaveBeenCalled();
+          const err = next.mock.calls[0][0];
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toBe("API error");
         });
       });
     });
@@ -385,13 +379,13 @@ describe("oauth middleware", () => {
         },
       };
 
-      req.customFetch = sinon.fake.returns({});
+      req.customFetch = vi.fn().mockReturnValue({});
     });
 
     it("should successfully redirects when code is valid", async () => {
       await middleware.redirectToCallback(req, res, next);
 
-      expect(res.redirect).to.have.been.calledWith(
+      expect(res.redirect).toHaveBeenCalledWith(
         `${redirect}?client_id=${clientId}&code=${code}&state=${state}`,
       );
     });
@@ -409,7 +403,7 @@ describe("oauth middleware", () => {
 
       await middleware.redirectToCallback(req, res, next);
 
-      expect(res.redirect).to.have.been.calledWith(
+      expect(res.redirect).toHaveBeenCalledWith(
         `${redirect}?error=${errorCode}&error_description=${description}&state=${state}`,
       );
     });
@@ -419,20 +413,19 @@ describe("oauth middleware", () => {
 
       await middleware.redirectToCallback(req, res, next);
 
-      expect(next).to.have.been.calledWith(
-        sinon.match
-          .instanceOf(TypeError)
-          .and(sinon.match.has("code", "ERR_INVALID_URL")),
-      );
+      expect(next).toHaveBeenCalled();
+      const err = next.mock.calls[0][0];
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.code).toBe("ERR_INVALID_URL");
     });
 
-    context("with session.save available", () => {
+    describe("with session.save available", () => {
       let notifySessionSaved;
 
       beforeEach(() => {
-        res.redirect = sinon.stub();
+        res.redirect = vi.fn();
         notifySessionSaved = undefined;
-        req.session.save = sinon.stub().callsFake((sessionSavedCallback) => {
+        req.session.save = vi.fn((sessionSavedCallback) => {
           notifySessionSaved = sessionSavedCallback;
         });
       });
@@ -440,12 +433,12 @@ describe("oauth middleware", () => {
       it("does not redirect until the session has finished saving", async () => {
         await middleware.redirectToCallback(req, res, next);
 
-        expect(req.session.save).to.have.been.calledOnce;
-        expect(res.redirect).to.not.have.been.called;
+        expect(req.session.save).toHaveBeenCalledTimes(1);
+        expect(res.redirect).not.toHaveBeenCalled();
 
         notifySessionSaved(null); // success
 
-        expect(res.redirect).to.have.been.calledOnce;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
       });
 
       it("still redirects if the session save fails", async () => {
@@ -453,35 +446,38 @@ describe("oauth middleware", () => {
 
         notifySessionSaved(new Error("session save failed"));
 
-        expect(res.redirect).to.have.been.calledOnce;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
       });
     });
   });
 
   describe("redirectToAddress", () => {
     beforeEach(() => {
-      req.customFetch = sinon.fake.returns({});
+      req.customFetch = vi.fn().mockReturnValue({});
       req.app = {
-        get: sinon.stub(),
+        get: vi.fn(),
       };
-      res.redirect = sinon.stub();
+      res.redirect = vi.fn();
     });
 
     it("should successfully redirect back to address", async function () {
-      req.app.get.withArgs("APP.PATHS.ENTRYPOINT").returns("/app/entry");
-
+      req.app.get.mockImplementation((arg) => {
+        if (arg === "APP.PATHS.ENTRYPOINT") return "/app/entry";
+      });
       await middleware.redirectToEntryPoint(req, res, next);
 
-      expect(res.redirect).to.have.been.calledWith("/app/entry");
+      expect(res.redirect).toHaveBeenCalledWith("/app/entry");
     });
 
-    context("with session.save available", () => {
+    describe("with session.save available", () => {
       let notifySessionSaved;
 
       beforeEach(() => {
-        req.app.get.withArgs("APP.PATHS.ENTRYPOINT").returns("/app/entry");
+        req.app.get.mockImplementation((arg) => {
+          if (arg === "APP.PATHS.ENTRYPOINT") return "/app/entry";
+        });
         notifySessionSaved = undefined;
-        req.session.save = sinon.stub().callsFake((sessionSavedCallback) => {
+        req.session.save = vi.fn((sessionSavedCallback) => {
           notifySessionSaved = sessionSavedCallback;
         });
       });
@@ -489,12 +485,12 @@ describe("oauth middleware", () => {
       it("does not redirect until the session has finished saving", async () => {
         await middleware.redirectToEntryPoint(req, res, next);
 
-        expect(req.session.save).to.have.been.calledOnce;
-        expect(res.redirect).to.not.have.been.called;
+        expect(req.session.save).toHaveBeenCalledTimes(1);
+        expect(res.redirect).not.toHaveBeenCalled();
 
         notifySessionSaved(null); // success
 
-        expect(res.redirect).to.have.been.calledOnce;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
       });
 
       it("still redirects if the session save fails", async () => {
@@ -502,21 +498,19 @@ describe("oauth middleware", () => {
 
         notifySessionSaved(new Error("session save failed"));
 
-        expect(res.redirect).to.have.been.calledOnce;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
       });
-    });
 
-    context("with missing APP.PATHS.ENTRYPOINT", () => {
-      it("should call next with error", async () => {
-        await middleware.redirectToEntryPoint(req, res, next);
+      describe("with missing APP.PATHS.ENTRYPOINT", () => {
+        it("should call next with error", async () => {
+          req.app.get.mockImplementation(() => {});
+          await middleware.redirectToEntryPoint(req, res, next);
 
-        expect(next).to.have.been.calledWith(
-          sinon.match
-            .instanceOf(Error)
-            .and(
-              sinon.match.has("message", "Missing APP.PATHS.ENTRYPOINT value"),
-            ),
-        );
+          expect(next).toHaveBeenCalled();
+          const err = next.mock.calls[0][0];
+          expect(err).toBeInstanceOf(Error);
+          expect(err.message).toBe("Missing APP.PATHS.ENTRYPOINT value");
+        });
       });
     });
   });

--- a/test/analytics/application.test.js
+++ b/test/analytics/application.test.js
@@ -44,7 +44,7 @@ describe("Init", () => {
         "ga4ContainerId",
         "gtmJourney",
       );
-      expect(events.length).toEqual(2);
+      expect(events).toHaveLength(2);
       expect(events[0]).toContain("init new cookie banner");
       expect(events[1]).toContain("init new analytics");
     });
@@ -62,7 +62,7 @@ describe("Init", () => {
           "ga4ContainerId",
           "gtmJourney",
         );
-        expect(events.length).toEqual(2);
+        expect(events).toHaveLength(2);
         expect(events).toContain("init existing analytics");
         expect(events).toContain("init existing cookie banner");
       });
@@ -84,7 +84,7 @@ describe("Init", () => {
           isGa4Enabled,
           gtmContainerId: "gtmContainerId",
         });
-        expect(events.length).toEqual(1);
+        expect(events).toHaveLength(1);
         expect(events).toContain("init existing cookie banner");
       });
     });

--- a/test/analytics/application.test.js
+++ b/test/analytics/application.test.js
@@ -1,4 +1,4 @@
-const { expect } = require("chai");
+import { expect, describe, beforeEach, afterEach, it } from "vitest";
 
 describe("Init", () => {
   let events;
@@ -44,9 +44,9 @@ describe("Init", () => {
         "ga4ContainerId",
         "gtmJourney",
       );
-      expect(events.length).to.equal(2);
-      expect(events[0]).to.include("init new cookie banner");
-      expect(events[1]).to.include("init new analytics");
+      expect(events.length).toEqual(2);
+      expect(events[0]).toContain("init new cookie banner");
+      expect(events[1]).toContain("init new analytics");
     });
   });
 
@@ -62,9 +62,9 @@ describe("Init", () => {
           "ga4ContainerId",
           "gtmJourney",
         );
-        expect(events.length).to.equal(2);
-        expect(events).to.include("init existing analytics");
-        expect(events).to.include("init existing cookie banner");
+        expect(events.length).toEqual(2);
+        expect(events).toContain("init existing analytics");
+        expect(events).toContain("init existing cookie banner");
       });
     });
 
@@ -84,8 +84,8 @@ describe("Init", () => {
           isGa4Enabled,
           gtmContainerId: "gtmContainerId",
         });
-        expect(events.length).to.equal(1);
-        expect(events).to.include("init existing cookie banner");
+        expect(events.length).toEqual(1);
+        expect(events).toContain("init existing cookie banner");
       });
     });
   });

--- a/test/analytics/core.test.js
+++ b/test/analytics/core.test.js
@@ -1,4 +1,4 @@
-const { expect } = require("chai");
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
 describe("Core", () => {
   beforeEach(async () => {
@@ -44,13 +44,13 @@ describe("Core", () => {
 
   it("Sends data to the data layer", function () {
     global.window.DI.core.sendData({ foo: "bar" });
-    expect(global.window.dataLayer[0]).to.deep.equal({ foo: "bar" });
+    expect(global.window.dataLayer[0]).toEqual({ foo: "bar" });
   });
 
   it("Creates gtmscript tag", function () {
     global.window.DI.core.load("12345");
     var gtmElement = global.document.documentElement.firstChild.child;
-    expect(gtmElement.src).to.deep.equal(
+    expect(gtmElement.src).toEqual(
       "https://www.googletagmanager.com/gtm.js?id=12345",
     );
   });

--- a/test/analytics/pageViewTracker.test.js
+++ b/test/analytics/pageViewTracker.test.js
@@ -1,9 +1,4 @@
-const chai = require("chai");
-const sinon = require("sinon");
-const sinonChai = require("sinon-chai");
-const { expect } = require("chai");
-
-chai.use(sinonChai);
+import { describe, expect, beforeEach, afterEach, it, vi } from "vitest";
 
 describe("PageViewTracker", () => {
   let expected;
@@ -20,7 +15,7 @@ describe("PageViewTracker", () => {
         },
       },
     };
-    mockSendData = sinon.stub(global.window.DI.core, "sendData");
+    mockSendData = vi.spyOn(global.window.DI.core, "sendData");
     global.document = {
       html: "<html></html>",
       title: "some-title",
@@ -78,7 +73,7 @@ describe("PageViewTracker", () => {
   it("Returns a standard page view", function () {
     global.window.DI.analyticsGa4.trackers.PageViewTracker.init();
 
-    expect(mockSendData).to.have.been.calledWith(expected);
+    expect(mockSendData).toHaveBeenCalledWith(expected);
   });
 
   it("Sets the language to the value of the lng cookie if set", function () {
@@ -87,7 +82,7 @@ describe("PageViewTracker", () => {
     global.window.DI.analyticsGa4.trackers.PageViewTracker.init();
 
     expected.page_view.language = "cy";
-    expect(mockSendData).to.have.been.calledWith(expected);
+    expect(mockSendData).toHaveBeenCalledWith(expected);
   });
 
   it("Sets the status_code to the value of the http status code if set", function () {
@@ -96,7 +91,7 @@ describe("PageViewTracker", () => {
     global.window.DI.analyticsGa4.trackers.PageViewTracker.init();
 
     expected.page_view.status_code = 401;
-    expect(mockSendData).to.have.been.calledWith(expected);
+    expect(mockSendData).toHaveBeenCalledWith(expected);
   });
 
   it("Sets title, location, referrer and language to lowercase if they contain uppercase characters", function () {
@@ -107,6 +102,6 @@ describe("PageViewTracker", () => {
 
     global.window.DI.analyticsGa4.trackers.PageViewTracker.init();
 
-    expect(mockSendData).to.have.been.calledWith(expected);
+    expect(mockSendData).toHaveBeenCalledWith(expected);
   });
 });

--- a/test/bootstrap/helper.js
+++ b/test/bootstrap/helper.js
@@ -1,10 +1,7 @@
-const chai = require("chai");
-const resolve = require("path").resolve;
-chai.use(require("sinon-chai"));
+import { vi } from "vitest";
 
-global.should = chai.should();
-global.expect = chai.expect;
-global.sinon = require("sinon");
+const resolve = require("path").resolve;
+
 global.APP_ROOT = resolve(__dirname, "..", "..");
 
 global.CONFIG_RESET = () => {
@@ -23,14 +20,16 @@ global.CONFIG_RESET = () => {
 
 global.LOGGER_RESET = () => {
   const loggerStub = {
-    info: sinon.stub(),
-    error: sinon.stub(),
-    warn: sinon.stub(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   };
 
   const logger = require(APP_ROOT + "/src/bootstrap/lib/logger");
-  if (logger.get.restore) logger.get.restore();
-  sinon.stub(logger, "get").returns(loggerStub);
+  if (vi.isMockFunction(logger.get)) {
+    logger.get.mockRestore();
+  }
+  vi.spyOn(logger, "get").mockReturnValue(loggerStub);
 
   return loggerStub;
 };

--- a/test/bootstrap/lib/spec.config.js
+++ b/test/bootstrap/lib/spec.config.js
@@ -1,67 +1,75 @@
+import { describe, beforeEach, afterEach, it, vi, expect } from "vitest";
+
 const hmpoConfig = require("hmpo-config");
 const config = require(APP_ROOT + "/src/bootstrap/lib/config");
 
 describe("Config", () => {
   beforeEach(() => {
-    sinon.stub(hmpoConfig.prototype, "addConfig");
-    sinon.stub(hmpoConfig.prototype, "addFile");
-    sinon.stub(hmpoConfig.prototype, "addString");
-    sinon.stub(hmpoConfig.prototype, "toJSON").returns({ returned: "config" });
+    vi.spyOn(hmpoConfig.prototype, "addConfig");
+    vi.spyOn(hmpoConfig.prototype, "addFile");
+    vi.spyOn(hmpoConfig.prototype, "addString");
+    vi.spyOn(hmpoConfig.prototype, "toJSON").mockReturnValue({
+      returned: "config",
+    });
     delete global.GLOBAL_CONFIG;
   });
 
   afterEach(() => {
-    hmpoConfig.prototype.addConfig.restore();
-    hmpoConfig.prototype.addFile.restore();
-    hmpoConfig.prototype.addString.restore();
-    hmpoConfig.prototype.toJSON.restore();
+    hmpoConfig.prototype.addConfig.mockRestore();
+    hmpoConfig.prototype.addFile.mockRestore();
+    hmpoConfig.prototype.addString.mockRestore();
+    hmpoConfig.prototype.toJSON.mockRestore();
     CONFIG_RESET();
   });
 
   it("exports functions", () => {
-    config.should.be.a("function");
-    config.setup.should.be.a("function");
-    config.get.should.be.a("function");
-    config.get.should.equal(config);
+    expect(typeof config).toBe("function");
+    expect(typeof config.setup).toBe("function");
+    expect(typeof config.get).toBe("function");
+    expect(config.get).toEqual(config);
   });
 
   describe("setup", () => {
     it("loads config using defaults", () => {
       config.setup();
 
-      hmpoConfig.prototype.addFile.should.have.been.calledThrice;
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly(
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledTimes(3);
+
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith(
         "config/default.json",
       );
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly(
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith(
         "config/default.yaml",
       );
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly(
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith(
         "config/default.yml",
       );
-      hmpoConfig.prototype.addConfig.should.not.have.been.called;
-      hmpoConfig.prototype.addString.should.not.have.been.called;
 
-      global.GLOBAL_CONFIG.should.eql({ returned: "config" });
+      // expect(hmpoConfig.prototype.addConfig).not.toHaveBeenCalled();
+      expect(hmpoConfig.prototype.addString).not.toHaveBeenCalled();
+
+      expect(global.GLOBAL_CONFIG).toEqual({ returned: "config" });
     });
 
     it("loads config using specified files", () => {
       config.setup({ files: ["a.json", "b.json"] });
 
-      hmpoConfig.prototype.addFile.should.have.been.calledTwice;
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly("a.json");
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly("b.json");
-      hmpoConfig.prototype.addConfig.should.not.have.been.called;
-      hmpoConfig.prototype.addString.should.not.have.been.called;
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledTimes(2);
 
-      global.GLOBAL_CONFIG.should.eql({ returned: "config" });
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith("a.json");
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith("b.json");
+
+      // expect(hmpoConfig.prototype.addConfig).not.toHaveBeenCalled();
+      expect(hmpoConfig.prototype.addString).not.toHaveBeenCalled();
+
+      expect(global.GLOBAL_CONFIG).toEqual({ returned: "config" });
     });
 
     it("merges config config using defaults", () => {
       config.setup();
       config.setup();
 
-      hmpoConfig.prototype.addConfig.should.have.been.calledWithExactly({
+      expect(hmpoConfig.prototype.addConfig).toHaveBeenCalledWith({
         returned: "config",
       });
     });
@@ -72,7 +80,7 @@ describe("Config", () => {
       };
       config.setup({ _environmentVariables: env });
 
-      hmpoConfig.prototype.addString.should.have.been.calledWithExactly(
+      expect(hmpoConfig.prototype.addString).toHaveBeenCalledWith(
         '{ config: "string" }',
       );
     });
@@ -90,56 +98,56 @@ describe("Config", () => {
       ];
       config.setup({ _commandLineArgs: args });
 
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly(
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith(
         "configfile.json",
       );
-      hmpoConfig.prototype.addFile.should.have.been.calledWithExactly(
+      expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith(
         "configfile.yaml",
       );
     });
 
     it("sets the timezone if specified in config", () => {
       const env = {};
-      hmpoConfig.prototype.toJSON.returns({ timezone: "BST" });
+      hmpoConfig.prototype.toJSON.mockReturnValue({ timezone: "BST" });
       config.setup({ _environmentVariables: env });
 
-      env.TZ.should.equal("BST");
+      expect(env.TZ).toEqual("BST");
     });
   });
 
   describe("get", () => {
     it("throws an error if no config is loaded", () => {
-      expect(() => config.get("key")).to.throw("Config not loaded");
+      expect(() => config.get("key")).toThrow("Config not loaded");
     });
 
     it("returns a value from config", () => {
       global.GLOBAL_CONFIG = { key: "value" };
       const result = config.get("key");
-      result.should.equal("value");
+      expect(result).toEqual("value");
     });
 
     it("returns a deep value from config", () => {
       global.GLOBAL_CONFIG = { obj: { obj2: { key: "value" } } };
       const result = config.get("obj.obj2.key");
-      result.should.equal("value");
+      expect(result).toEqual("value");
     });
 
     it("returns undefined if any part of the path is not found", () => {
       global.GLOBAL_CONFIG = { obj: { obj2: { key: "value" } } };
       const result = config.get("obj.obj3.key");
-      expect(result).to.be.undefined;
+      expect(result).toBeUndefined();
     });
 
     it("returns default value if any part of the path is not found", () => {
       global.GLOBAL_CONFIG = { obj: { obj2: { key: "value" } } };
       const result = config.get("obj.obj3.key", "default");
-      result.should.equal("default");
+      expect(result).toEqual("default");
     });
 
     it("returns config root with no path specified", () => {
       global.GLOBAL_CONFIG = { obj: { obj2: { key: "value" } } };
       const result = config.get();
-      result.should.equal(global.GLOBAL_CONFIG);
+      expect(result).toEqual(global.GLOBAL_CONFIG);
     });
   });
 });

--- a/test/bootstrap/lib/spec.config.js
+++ b/test/bootstrap/lib/spec.config.js
@@ -45,7 +45,7 @@ describe("Config", () => {
         "config/default.yml",
       );
 
-      // expect(hmpoConfig.prototype.addConfig).not.toHaveBeenCalled();
+      expect(hmpoConfig.prototype.addConfig).toHaveBeenCalled();
       expect(hmpoConfig.prototype.addString).not.toHaveBeenCalled();
 
       expect(global.GLOBAL_CONFIG).toEqual({ returned: "config" });
@@ -59,7 +59,7 @@ describe("Config", () => {
       expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith("a.json");
       expect(hmpoConfig.prototype.addFile).toHaveBeenCalledWith("b.json");
 
-      // expect(hmpoConfig.prototype.addConfig).not.toHaveBeenCalled();
+      expect(hmpoConfig.prototype.addConfig).toHaveBeenCalled();
       expect(hmpoConfig.prototype.addString).not.toHaveBeenCalled();
 
       expect(global.GLOBAL_CONFIG).toEqual({ returned: "config" });

--- a/test/bootstrap/lib/spec.logger.js
+++ b/test/bootstrap/lib/spec.logger.js
@@ -311,7 +311,7 @@ describe("Logger", () => {
 
       const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.code).toEqual(undefined);
+      expect(arg.code).toBeUndefined();
     });
 
     it("should redact sensitive query params from request", function () {

--- a/test/bootstrap/lib/spec.logger.js
+++ b/test/bootstrap/lib/spec.logger.js
@@ -1,11 +1,15 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+
 const hmpoLogger = require("hmpo-logger");
 const logger = require(APP_ROOT + "/src/bootstrap/lib/logger");
 
 describe("Logger", () => {
   beforeEach(() => {
-    sinon.stub(hmpoLogger, "config");
-    sinon.stub(hmpoLogger, "get").returns("logger instance");
-    if (logger.get.restore) logger.get.restore();
+    vi.spyOn(hmpoLogger, "config");
+    vi.spyOn(hmpoLogger, "get").mockReturnValue("logger instance");
+    if (vi.isMockFunction(logger.get)) {
+      logger.get.mockRestore();
+    }
   });
 
   describe("redactQueryParams", () => {
@@ -42,7 +46,7 @@ describe("Logger", () => {
         const actual = logger.redactQueryParams(input);
 
         // Assert
-        expect(actual).to.equal(output);
+        expect(actual).toEqual(output);
       });
     });
   });
@@ -54,33 +58,33 @@ describe("Logger", () => {
   });
 
   it("exports functions", () => {
-    logger.should.be.a("function");
-    logger.setup.should.be.a("function");
-    logger.get.should.be.a("function");
-    logger.get.should.equal(logger);
+    expect(typeof logger).toBe("function");
+    expect(typeof logger.setup).toBe("function");
+    expect(typeof logger.get).toBe("function");
+    expect(logger.get).toEqual(logger);
   });
 
   describe("setup", () => {
     it("configures logger from options", () => {
       logger.setup({ foo: "bar" });
-      hmpoLogger.config.should.have.been.calledWithExactly({ foo: "bar" });
+      expect(hmpoLogger.config).toHaveBeenCalledWith({ foo: "bar" });
     });
 
     it("configures logger from config", () => {
       logger.setup();
-      hmpoLogger.config.should.have.been.calledWithExactly({ console: true });
+      expect(hmpoLogger.config).toHaveBeenCalledWith({ console: true });
     });
   });
 
   describe("get", () => {
     it("returns a named logger", () => {
       logger.get("name");
-      hmpoLogger.get.should.have.been.calledWithExactly("name", 2);
+      expect(hmpoLogger.get).toHaveBeenCalledWith("name", 2);
     });
 
     it("returns a default logger", () => {
       logger.get();
-      hmpoLogger.get.should.have.been.calledWithExactly(":hmpo-app", 2);
+      expect(hmpoLogger.get).toHaveBeenCalledWith(":hmpo-app", 2);
     });
 
     it("uses hmpo-logger when USE_PINO_LOGGER is not 'true'", () => {
@@ -88,7 +92,7 @@ describe("Logger", () => {
       delete process.env.USE_PINO_LOGGER;
 
       logger.get("fallback-test");
-      hmpoLogger.get.should.have.been.calledWithExactly("fallback-test", 2);
+      expect(hmpoLogger.get).toHaveBeenCalledWith("fallback-test", 2);
 
       if (typeof prev !== "undefined") {
         process.env.USE_PINO_LOGGER = prev;
@@ -131,11 +135,11 @@ describe("Logger", () => {
 
         const serialized = getSerializers().err(err);
 
-        expect(serialized.type).to.equal("Error");
-        expect(serialized.message).to.equal("Something failed");
-        expect(serialized.stack).to.be.a("string");
-        expect(serialized.code).to.equal("FAIL");
-        expect(serialized.status).to.equal(403);
+        expect(serialized.type).toEqual("Error");
+        expect(serialized.message).toEqual("Something failed");
+        expect(typeof serialized.stack).toBe("string");
+        expect(serialized.code).toEqual("FAIL");
+        expect(serialized.status).toEqual(403);
       });
 
       it("serializes the original error when present", () => {
@@ -146,9 +150,9 @@ describe("Logger", () => {
 
         const serialized = getSerializers().err(err);
 
-        expect(serialized.original.message).to.equal("Root cause");
-        expect(serialized.original.code).to.equal("ROOT");
-        expect(serialized.original.stack).to.be.a("string");
+        expect(serialized.original.message).toEqual("Root cause");
+        expect(serialized.original.code).toEqual("ROOT");
+        expect(typeof serialized.original.stack).toBe("string");
       });
 
       it("serializes request meta for hmpo-logger parity", () => {
@@ -163,7 +167,7 @@ describe("Logger", () => {
           headers: { "x-uniq-id": "uniq-123" },
         });
 
-        expect(serialized).to.deep.equal({
+        expect(serialized).toEqual({
           method: "GET",
           url: "/test?code=hidden",
           clientip: "127.0.0.1",
@@ -185,7 +189,7 @@ describe("Logger", () => {
           getHeader: (name) => headers[name],
         });
 
-        expect(serialized).to.deep.equal({
+        expect(serialized).toEqual({
           statusCode: 302,
           sessionId: "session-1",
           location: "/done?code=hidden",
@@ -214,19 +218,19 @@ describe("Logger", () => {
     };
 
     beforeEach(function () {
-      sinon.restore();
+      vi.restoreAllMocks();
 
       process.env.USE_PINO_LOGGER = "true";
 
       mockLogger = {
-        error: sinon.stub(),
-        info: sinon.stub(),
-        warn: sinon.stub(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
       };
     });
 
     afterEach(function () {
-      sinon.restore();
+      vi.restoreAllMocks();
       delete process.env.USE_PINO_LOGGER;
       delete process.env.NODE_ENV;
     });
@@ -234,14 +238,14 @@ describe("Logger", () => {
     it("should log structured error in Pino mode", function () {
       logger.logError(mockReq, mockErr(), { logger: mockLogger });
 
-      expect(mockLogger.error.calledOnce).to.equal(true);
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.code).to.equal("FAIL");
-      expect(arg.method).to.equal("GET");
-      expect(arg.request).to.equal("/search?q=test&code=hidden");
-      expect(arg.message.includes("Something failed")).to.equal(true);
+      expect(arg.code).toEqual("FAIL");
+      expect(arg.method).toEqual("GET");
+      expect(arg.request).toEqual("/search?q=test&code=hidden");
+      expect(arg.message.includes("Something failed")).toEqual(true);
     });
 
     it("should include prefix in message", function () {
@@ -250,9 +254,9 @@ describe("Logger", () => {
         messagePrefix: "Added Start",
       });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.message.startsWith("Added Start:")).to.equal(true);
+      expect(arg.message.startsWith("Added Start:")).toEqual(true);
     });
 
     it("should include error properties such as status at top level", function () {
@@ -261,10 +265,10 @@ describe("Logger", () => {
 
       logger.logError(mockReq, err, { logger: mockLogger });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.status).to.equal(403);
-      expect(arg.code).to.equal("FAIL");
+      expect(arg.status).toEqual(403);
+      expect(arg.code).toEqual("FAIL");
     });
 
     it("should include the stack as an array of lines at top level", function () {
@@ -273,9 +277,9 @@ describe("Logger", () => {
 
       logger.logError(mockReq, err, { logger: mockLogger });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.stack).to.deep.equal(["line one", "line two"]);
+      expect(arg.stack).toEqual(["line one", "line two"]);
     });
 
     it("should include the original error at top level", function () {
@@ -284,9 +288,9 @@ describe("Logger", () => {
 
       logger.logError(mockReq, err, { logger: mockLogger });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.original.message).to.equal("Root cause");
+      expect(arg.original.message).toEqual("Root cause");
     });
 
     it("should include clientip and sessionID", function () {
@@ -294,10 +298,10 @@ describe("Logger", () => {
         logger: mockLogger,
       });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.clientip).to.equal("127.0.0.1");
-      expect(arg.sessionID).to.equal("session-1");
+      expect(arg.clientip).toEqual("127.0.0.1");
+      expect(arg.sessionID).toEqual("session-1");
     });
 
     it("should omit code if not present", function () {
@@ -305,17 +309,17 @@ describe("Logger", () => {
 
       logger.logError(mockReq, err, { logger: mockLogger });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.code).to.equal(undefined);
+      expect(arg.code).toEqual(undefined);
     });
 
     it("should redact sensitive query params from request", function () {
       logger.logError(mockReq, mockErr(), { logger: mockLogger });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
-      expect(arg.request).to.equal("/search?q=test&code=hidden");
+      expect(arg.request).toEqual("/search?q=test&code=hidden");
     });
 
     it("should include stack in non-production", function () {
@@ -323,7 +327,7 @@ describe("Logger", () => {
 
       logger.logError(mockReq, mockErr(), { logger: mockLogger });
 
-      const arg = mockLogger.error.firstCall.args[0];
+      const arg = mockLogger.error.mock.calls[0][0];
 
       expect(arg.err.stack).to.exist;
     });
@@ -333,13 +337,13 @@ describe("Logger", () => {
 
       logger.logError(mockReq, mockErr(), { logger: mockLogger });
 
-      expect(mockLogger.error.calledOnce).to.equal(true);
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
 
-      const args = mockLogger.error.firstCall.args;
+      const args = mockLogger.error.mock.calls[0];
 
-      expect(args[0]).to.equal(":clientip :verb :request :err.message");
-      expect(args[1].req).to.exist;
-      expect(args[1].err).to.exist;
+      expect(args[0]).toEqual(":clientip :verb :request :err.message");
+      expect(args[1].req).toBeDefined();
+      expect(args[1].err).toBeDefined();
     });
   });
 });

--- a/test/bootstrap/lib/spec.overload-protection.js
+++ b/test/bootstrap/lib/spec.overload-protection.js
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 const { configure } = require("../../../src/bootstrap/lib/overload-protection");
 
 describe("overload-protection (configure)", () => {
@@ -5,7 +6,7 @@ describe("overload-protection (configure)", () => {
     it("should have default values", () => {
       const values = configure();
 
-      expect(values).to.deep.equal({
+      expect(values).toEqual({
         production: "production",
         clientRetrySecs: 1,
         sampleInterval: 5,
@@ -33,7 +34,7 @@ describe("overload-protection (configure)", () => {
 
       const values = configure(parameters);
 
-      expect(values).to.deep.equal(parameters);
+      expect(values).toEqual(parameters);
     });
 
     it("should have use partial overrides from parameters with fallback defaults", () => {
@@ -44,7 +45,7 @@ describe("overload-protection (configure)", () => {
 
       const values = configure(parameters);
 
-      expect(values).to.deep.equal({
+      expect(values).toEqual({
         clientRetrySecs: 1,
         errorPropagationMode: false,
         logStatsOnReq: false,
@@ -70,7 +71,7 @@ describe("overload-protection (configure)", () => {
     it("should have use overrides for maxEventLoopDelay from environment", () => {
       const values = configure();
 
-      expect(values).to.deep.equal({
+      expect(values).toEqual({
         production: "production",
         clientRetrySecs: 1,
         sampleInterval: 5,
@@ -86,7 +87,7 @@ describe("overload-protection (configure)", () => {
     it("should have use overrides maxEventLoopDelay from parameters before environment", () => {
       const values = configure({ maxEventLoopDelay: 1200 });
 
-      expect(values).to.deep.equal({
+      expect(values).toEqual({
         production: "production",
         clientRetrySecs: 1,
         sampleInterval: 5,

--- a/test/bootstrap/lib/spec.redis-client.js
+++ b/test/bootstrap/lib/spec.redis-client.js
@@ -1,3 +1,5 @@
+import { describe, vi, expect, beforeEach, afterEach, it } from "vitest";
+
 const redis = require("redis");
 const fakeredis = require("fakeredis");
 const redisClient = require(APP_ROOT + "/src/bootstrap/lib/redis-client");
@@ -8,73 +10,73 @@ describe("Redis Client", () => {
   beforeEach(() => {
     redisStub = {
       connected: true,
-      connect: sinon.stub(),
-      sendCommand: sinon.stub(),
-      on: sinon.stub(),
-      once: sinon.stub(),
-      quit: sinon.stub(),
+      connect: vi.fn(),
+      sendCommand: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      quit: vi.fn(),
     };
     fakeredisStub = { ...redisStub };
 
-    sinon.stub(redis, "createClient").returns(redisStub);
-    sinon.stub(fakeredis, "createClient").returns(fakeredisStub);
+    vi.spyOn(redis, "createClient").mockReturnValue(redisStub);
+    vi.spyOn(fakeredis, "createClient").mockReturnValue(fakeredisStub);
     redisClient.client = null;
 
     loggerStub = LOGGER_RESET();
   });
 
   afterEach(() => {
-    redis.createClient.restore();
-    fakeredis.createClient.restore();
+    redis.createClient.mockRestore();
+    fakeredis.createClient.mockRestore();
   });
 
   it("exports functions", () => {
-    redisClient.should.be.a("function");
-    redisClient.getClient.should.equal(redisClient);
-    redisClient.setup.should.be.a("function");
-    redisClient.close.should.be.a("function");
+    expect(typeof redisClient).toBe("function");
+    expect(redisClient.getClient).toEqual(redisClient);
+    expect(typeof redisClient.setup).toBe("function");
+    expect(typeof redisClient.close).toBe("function");
   });
 
   describe("setup", () => {
     it("creates a new redis client", () => {
       const client = redisClient.setup({ host: "abc123", port: 123 });
-      redis.createClient.should.have.been.calledOnce;
-      redis.createClient.should.have.been.calledWithExactly({
+      expect(redis.createClient).toHaveBeenCalledTimes(1);
+      expect(redis.createClient).toHaveBeenCalledWith({
         legacyMode: true,
         socket: {
           port: 123,
           host: "abc123",
         },
       });
-      redisStub.connect.should.have.been.called;
-      client.should.equal(redisStub);
-      redisClient.client.should.equal(client);
+      expect(redisStub.connect).toHaveBeenCalled();
+      expect(client).toEqual(redisStub);
+      expect(redisClient.client).toEqual(client);
     });
 
     it("creates a new redis client using default port", () => {
       redisClient.setup({ host: "abc123" });
-      redis.createClient.should.have.been.calledWithExactly({
+      expect(redis.createClient).toHaveBeenCalledWith({
         legacyMode: true,
         socket: {
           port: 6379,
           host: "abc123",
         },
       });
-      redisStub.connect.should.have.been.called;
+      expect(redisStub.connect).toHaveBeenCalled();
     });
 
     it("creates a new redis client with a connection string", () => {
       const client = redisClient.setup({
         connectionString: "user:pass@host:port",
       });
-      redis.createClient.should.have.been.calledOnce;
-      redis.createClient.should.have.been.calledWithExactly({
+      expect(redis.createClient).toHaveBeenCalledTimes(1);
+      expect(redis.createClient).toHaveBeenCalledWith({
         legacyMode: true,
         url: "user:pass@host:port",
       });
-      redisStub.connect.should.have.been.called;
-      client.should.equal(redisStub);
-      redisClient.client.should.equal(client);
+      expect(redisStub.connect).toHaveBeenCalled();
+      expect(client).toEqual(redisStub);
+      expect(redisClient.client).toEqual(client);
     });
 
     it("passes other redis options to redis", () => {
@@ -82,12 +84,12 @@ describe("Redis Client", () => {
         connectionString: "user:pass@host:port",
         foo: "bar",
       });
-      redis.createClient.should.have.been.calledWithExactly({
+      expect(redis.createClient).toHaveBeenCalledWith({
         legacyMode: true,
         foo: "bar",
         url: "user:pass@host:port",
       });
-      redisStub.connect.should.have.been.called;
+      expect(redisStub.connect).toHaveBeenCalled();
     });
 
     it("reconnects to redis if there is an existing redis client", () => {
@@ -95,107 +97,123 @@ describe("Redis Client", () => {
       const client = redisClient.setup({
         connectionString: "user:pass@host:port",
       });
-      redisStub.quit.should.have.been.called;
-      redis.createClient.should.have.been.calledOnce;
-      redis.createClient.should.have.been.calledWithExactly({
+      expect(redisStub.quit).toHaveBeenCalled();
+      expect(redis.createClient).toHaveBeenCalledTimes(1);
+      expect(redis.createClient).toHaveBeenCalledWith({
         legacyMode: true,
         url: "user:pass@host:port",
       });
-      redisStub.connect.should.have.been.called;
-      redisClient.client.should.equal(client);
+      expect(redisStub.connect).toHaveBeenCalled();
+      expect(redisClient.client).toEqual(client);
     });
 
     it("should log an error redis error event", () => {
-      redisStub.on.withArgs("error").yields(new Error());
+      redisStub.on.mockImplementation((event, callback) => {
+        if (event === "error") {
+          callback(new Error());
+        }
+      });
       redisClient.setup({ connectionString: "user:pass@host:port" });
-      loggerStub.error.should.have.been.called;
+      expect(loggerStub.error).toHaveBeenCalled();
     });
 
     it("should handle connect events", () => {
-      redisStub.on.withArgs("connect").yields();
+      redisStub.on.mockImplementationOnce((event, callback) => {
+        if (event === "connect") {
+          callback();
+        }
+      });
       redisClient.setup({ connectionString: "user:pass@host:port" });
-      loggerStub.info.should.have.been.called;
-      redisStub.sendCommand.should.have.been.calledWithExactly("CLIENT", [
+      expect(loggerStub.info).toHaveBeenCalled();
+      expect(redisStub.sendCommand).toHaveBeenCalledWith("CLIENT", [
         "SETNAME",
-        sinon.match.string,
+        expect.any(String),
       ]);
     });
 
     it("should handle reconnect events", () => {
-      redisStub.on.withArgs("reconnecting").yields();
+      redisStub.on.mockImplementation((event, callback) => {
+        if (event === "reconnecting") {
+          callback();
+        }
+      });
       redisClient.setup({ connectionString: "user:pass@host:port" });
-      loggerStub.info.should.have.been.called;
+      expect(loggerStub.info).toHaveBeenCalled();
     });
 
     it("should create a in-memory redis server with no connection details", () => {
       let client = redisClient.setup();
 
-      redis.createClient.should.not.have.been.called;
+      expect(redis.createClient).not.toHaveBeenCalled();
 
-      fakeredis.createClient.should.have.been.calledOnce;
-      fakeredis.createClient.should.have.been.calledWithExactly();
+      expect(fakeredis.createClient).toHaveBeenCalledTimes(1);
+      expect(fakeredis.createClient).toHaveBeenCalledWith();
 
-      client.should.equal(fakeredisStub);
-      redisClient.client.should.equal(client);
+      expect(client).toEqual(fakeredisStub);
+      expect(redisClient.client).toEqual(client);
     });
 
     it("should log an error fake redis error event", () => {
-      redisStub.on.withArgs("error").yields(new Error());
+      redisStub.on.mockImplementationOnce((event, callback) => {
+        if (event === "error") {
+          callback(new Error());
+        }
+      });
       redisClient.setup();
-      loggerStub.error.should.have.been.called;
+      expect(loggerStub.error).toHaveBeenCalled();
     });
   });
 
   describe("close", () => {
     it("closes an existing connected client connection", () => {
-      let cb = sinon.stub();
+      let cb = vi.fn();
       redisClient.client = redisStub;
       redisClient.close(cb);
-      redisStub.once.should.have.been.calledWithExactly("end", cb);
-      redisStub.quit.should.have.been.calledWithExactly();
-      expect(redisClient.client).to.be.null;
+      expect(redisStub.once).toHaveBeenCalledWith("end", cb);
+      expect(redisStub.quit).toHaveBeenCalledWith();
+      expect(redisClient.client).toBe(null);
     });
 
     it("calls the callback if the client is not connected", () => {
-      let cb = sinon.stub();
+      let cb = vi.fn();
       redisStub.connected = false;
       redisClient.client = redisStub;
       redisClient.close(cb);
-      cb.should.have.been.calledOnce;
-      redisStub.quit.should.not.have.been.called;
-      expect(redisClient.client).to.be.null;
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(redisStub.quit).not.toHaveBeenCalled();
+      expect(redisClient.client).toBe(null);
     });
 
     it("calls the callback if there is no redis client", () => {
-      let cb = sinon.stub();
+      let cb = vi.fn();
       redisClient.close(cb);
-      cb.should.have.been.calledOnce;
-      redisStub.quit.should.not.have.been.called;
-      expect(redisClient.client).to.be.null;
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(redisStub.quit).not.toHaveBeenCalled();
+      expect(redisClient.client).toBe(null);
     });
 
     it("does nothing if there is no redis client and no callback specified", () => {
       redisClient.close();
-      redisStub.quit.should.not.have.been.called;
-      expect(redisClient.client).to.be.null;
+      expect(redisStub.quit).not.toHaveBeenCalled();
+      expect(redisClient.client).toBe(null);
     });
   });
 
   describe("getClient", () => {
     it("should return the current client", () => {
-      expect(redisClient.getClient()).to.be.null;
-      expect(redisClient()).to.be.null;
+      expect(redisClient.getClient()).toBe(null);
+      expect(redisClient()).toBe(null);
 
       redisClient.setup();
 
-      redisClient.getClient().should.equal(fakeredisStub);
-      redisClient.getClient().should.equal(redisClient.client);
-      redisClient().should.equal(redisClient.client);
+      expect(redisClient.getClient()).toEqual(fakeredisStub);
+      expect(redisClient.getClient()).toEqual(redisClient.client);
+      expect(redisClient()).toEqual(redisClient.client);
 
       redisClient.close();
 
-      expect(redisClient.getClient()).to.be.null;
-      expect(redisClient()).to.be.null;
+      expect(redisClient.getClient()).toBe(null);
+      expect(redisClient()).toBe(null);
     });
   });
 });

--- a/test/bootstrap/lib/spec.redis-client.js
+++ b/test/bootstrap/lib/spec.redis-client.js
@@ -171,7 +171,7 @@ describe("Redis Client", () => {
       redisClient.close(cb);
       expect(redisStub.once).toHaveBeenCalledWith("end", cb);
       expect(redisStub.quit).toHaveBeenCalledWith();
-      expect(redisClient.client).toBe(null);
+      expect(redisClient.client).toBeNull();
     });
 
     it("calls the callback if the client is not connected", () => {
@@ -181,7 +181,7 @@ describe("Redis Client", () => {
       redisClient.close(cb);
       expect(cb).toHaveBeenCalledTimes(1);
       expect(redisStub.quit).not.toHaveBeenCalled();
-      expect(redisClient.client).toBe(null);
+      expect(redisClient.client).toBeNull();
     });
 
     it("calls the callback if there is no redis client", () => {
@@ -189,20 +189,20 @@ describe("Redis Client", () => {
       redisClient.close(cb);
       expect(cb).toHaveBeenCalledTimes(1);
       expect(redisStub.quit).not.toHaveBeenCalled();
-      expect(redisClient.client).toBe(null);
+      expect(redisClient.client).toBeNull();
     });
 
     it("does nothing if there is no redis client and no callback specified", () => {
       redisClient.close();
       expect(redisStub.quit).not.toHaveBeenCalled();
-      expect(redisClient.client).toBe(null);
+      expect(redisClient.client).toBeNull();
     });
   });
 
   describe("getClient", () => {
     it("should return the current client", () => {
-      expect(redisClient.getClient()).toBe(null);
-      expect(redisClient()).toBe(null);
+      expect(redisClient.getClient()).toBeNull();
+      expect(redisClient()).toBeNull();
 
       redisClient.setup();
 
@@ -212,8 +212,8 @@ describe("Redis Client", () => {
 
       redisClient.close();
 
-      expect(redisClient.getClient()).toBe(null);
-      expect(redisClient()).toBe(null);
+      expect(redisClient.getClient()).toBeNull();
+      expect(redisClient()).toBeNull();
     });
   });
 });

--- a/test/bootstrap/middleware/spec.compatibility.js
+++ b/test/bootstrap/middleware/spec.compatibility.js
@@ -1,3 +1,5 @@
+import { describe, it, expect, vi } from "vitest";
+
 const compatibility = require(
   APP_ROOT + "/src/bootstrap/middleware/compatibility",
 );
@@ -5,7 +7,8 @@ const compatibility = require(
 describe("Compatibility", () => {
   it("exports a middleware function", () => {
     const fn = compatibility.middleware();
-    fn.should.be.a("function").and.have.length(3);
+    expect(typeof fn).toBe("function");
+    expect(fn).toHaveLength(3);
   });
 
   describe("middleware", () => {
@@ -13,18 +16,18 @@ describe("Compatibility", () => {
       const fn = compatibility.middleware();
       const req = {};
       const res = {
-        setHeader: sinon.stub(),
+        setHeader: vi.fn(),
       };
-      const next = sinon.stub();
+      const next = vi.fn();
 
       fn(req, res, next);
 
-      res.setHeader.should.have.been.calledWithExactly(
+      expect(res.setHeader).toHaveBeenCalledWith(
         "X-UA-Compatible",
         "IE=edge,chrome=1",
       );
 
-      next.should.have.been.calledOnce.and.calledWithExactly();
+      expect(next).toHaveBeenCalled();
     });
   });
 });

--- a/test/bootstrap/middleware/spec.cookies.js
+++ b/test/bootstrap/middleware/spec.cookies.js
@@ -1,3 +1,5 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 const cookies = require(APP_ROOT + "/src/bootstrap/middleware/cookies");
 
 describe("Cookies", () => {
@@ -6,37 +8,41 @@ describe("Cookies", () => {
 
     beforeEach(() => {
       [parser, fn] = cookies.middleware({ secret: "abc123" });
-      cookieStub = sinon.stub();
+      cookieStub = vi.fn();
       req = {
         protocol: "http",
       };
       res = {
         cookie: cookieStub,
       };
-      next = sinon.stub();
+      next = vi.fn();
     });
 
     it("should create a cookie middleware", () => {
-      parser.should.be.a("function").and.have.length(3);
-      fn.should.be.a("function").and.have.length(3);
+      expect(typeof parser).toBe("function");
+      expect(parser).toHaveLength(3);
+      expect(typeof fn).toBe("function");
+      expect(fn).toHaveLength(3);
     });
 
     it("should default options to an empty object", () => {
       [parser, fn] = cookies.middleware();
-      parser.should.be.a("function").and.have.length(3);
-      fn.should.be.a("function").and.have.length(3);
+      expect(typeof parser).toBe("function");
+      expect(parser).toHaveLength(3);
+      expect(typeof fn).toBe("function");
+      expect(fn).toHaveLength(3);
     });
 
     it("should replace res.cookie with a function", () => {
       fn(req, res, next);
-      res.cookie.should.not.equal(cookieStub);
+      expect(res.cookie).not.toEqual(cookieStub);
     });
 
     it("should call the original res.cookie with secure values", () => {
       fn(req, res, next);
       res.cookie("name", "value");
-      cookieStub.should.have.been.calledOnce;
-      cookieStub.should.have.been.calledWithExactly("name", "value", {
+      expect(cookieStub).toHaveBeenCalledTimes(1);
+      expect(cookieStub).toHaveBeenCalledWith("name", "value", {
         secure: false,
         httpOnly: true,
         path: "/",
@@ -47,8 +53,8 @@ describe("Cookies", () => {
       fn(req, res, next);
       req.protocol = "https";
       res.cookie("name", "value");
-      cookieStub.should.have.been.calledOnce;
-      cookieStub.should.have.been.calledWithExactly("name", "value", {
+      expect(cookieStub).toHaveBeenCalledTimes(1);
+      expect(cookieStub).toHaveBeenCalledWith("name", "value", {
         secure: true,
         httpOnly: true,
         path: "/",
@@ -58,8 +64,8 @@ describe("Cookies", () => {
     it("should extend and override supplied options", () => {
       fn(req, res, next);
       res.cookie("name", "value", { expires: "now", httpOnly: false });
-      cookieStub.should.have.been.calledOnce;
-      cookieStub.should.have.been.calledWithExactly("name", "value", {
+      expect(cookieStub).toHaveBeenCalledTimes(1);
+      expect(cookieStub).toHaveBeenCalledWith("name", "value", {
         expires: "now",
         secure: false,
         httpOnly: true,

--- a/test/bootstrap/middleware/spec.error-handler.js
+++ b/test/bootstrap/middleware/spec.error-handler.js
@@ -1,3 +1,5 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
 const loggerModule = require("../../../src/bootstrap/lib/logger");
 const request = require("hmpo-reqres").req;
 
@@ -5,7 +7,7 @@ describe("Error Handler", () => {
   let req, res, next, errorhandler, middleware;
 
   beforeEach(() => {
-    sinon.restore();
+    vi.restoreAllMocks();
 
     req = request({
       baseUrl: "/my-app",
@@ -13,15 +15,15 @@ describe("Error Handler", () => {
       method: "GET",
     });
     res = {
-      render: sinon.stub(),
-      redirect: sinon.stub(),
+      render: vi.fn(),
+      redirect: vi.fn(),
       locals: {
         backLink: "/back",
       },
     };
-    next = sinon.stub();
+    next = vi.fn();
 
-    sinon.spy(loggerModule, "logError");
+    vi.spyOn(loggerModule, "logError");
 
     middleware = require(
       APP_ROOT + "/src/bootstrap/middleware/error-handler",
@@ -34,23 +36,23 @@ describe("Error Handler", () => {
 
   describe("middleware", () => {
     it("exports a function with length 4 - express identifies error handling middleware by its arguments length", () => {
-      errorhandler.should.be.a("function");
-      errorhandler.length.should.equal(4);
+      expect(typeof errorhandler).toBe("function");
+      expect(errorhandler).toHaveLength(4);
     });
 
     describe("redirects", () => {
       it("redirect instead of showing error page if redirect is present in error", () => {
         const err = { redirect: "/redirect/location" };
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledOnce;
-        res.redirect.should.have.been.calledWithExactly("/redirect/location");
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith("/redirect/location");
       });
 
       it("does not redirect if path matches the redirect", () => {
         req.path = "location///";
         const err = { redirect: "location" };
         errorhandler(err, req, res, next);
-        res.redirect.should.not.have.been.called;
+        expect(res.redirect).not.toHaveBeenCalled();
       });
 
       it("does redirect if on the POST of destination page", () => {
@@ -58,15 +60,15 @@ describe("Error Handler", () => {
         req.method = "POST";
         const err = { redirect: "/redirect/location" };
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledOnce;
-        res.redirect.should.have.been.calledWithExactly("/redirect/location");
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith("/redirect/location");
       });
 
       it("does not redirect if on a GET of the destination page", () => {
         req.path = "/redirect/location";
         const err = { redirect: "/redirect/location" };
         errorhandler(err, req, res, next);
-        res.redirect.should.not.have.been.called;
+        expect(res.redirect).not.toHaveBeenCalled();
       });
     });
 
@@ -80,10 +82,10 @@ describe("Error Handler", () => {
       it("does not include a back link for SESSION_TIMEOUT errors", () => {
         err.code = "SESSION_TIMEOUT";
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "errors/session-ended",
-          sinon.match({ backLink: null }),
+          expect.objectContaining({ backLink: null }),
         );
       });
 
@@ -91,19 +93,19 @@ describe("Error Handler", () => {
         req.path = "/foo";
         req.method = "POST";
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "errors/error",
-          sinon.match({ backLink: "/foo" }),
+          expect.objectContaining({ backLink: "/foo" }),
         );
       });
 
       it("sets res.locals.backLink as the back link for GETs", () => {
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "errors/error",
-          sinon.match({ backLink: "/back" }),
+          expect.objectContaining({ backLink: "/back" }),
         );
       });
     });
@@ -121,29 +123,29 @@ describe("Error Handler", () => {
 
       it("sets a default template and clears backlink", () => {
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "errors/session-ended",
-          sinon.match({ backLink: null }),
+          expect.objectContaining({ backLink: null }),
         );
       });
 
       it("doesn't overwrite a custom timeout template", () => {
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "test/template",
-          sinon.match({ backLink: null }),
+          expect.objectContaining({ backLink: null }),
         );
       });
 
       it("redirects to the base page if this is a new browser", () => {
         req.isNewBrowser = true;
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledOnce;
-        res.redirect.should.have.been.calledWith("/start");
-        res.render.should.not.have.been.called;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith("/start");
+        expect(res.render).not.toHaveBeenCalled();
       });
 
       it("redirects to a start page specified by a startUrl function", () => {
@@ -154,33 +156,33 @@ describe("Error Handler", () => {
             res.locals.htmlLang === "cy" ? "/welsh" : "/english",
         });
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledOnce;
-        res.redirect.should.have.been.calledWith("/welsh");
-        res.render.should.not.have.been.called;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith("/welsh");
+        expect(res.render).not.toHaveBeenCalled();
       });
 
       it("redirects to / if no startUrl is specified", () => {
         req.isNewBrowser = true;
         errorhandler = middleware();
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledWith("/");
+        expect(res.redirect).toHaveBeenCalledWith("/");
       });
 
       it("doesn't redirect to the base page if a custom template is given", () => {
         req.isNewBrowser = true;
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        res.redirect.should.not.have.been.called;
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.redirect).not.toHaveBeenCalled();
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "test/template",
-          sinon.match({ backLink: null }),
+          expect.objectContaining({ backLink: null }),
         );
       });
 
       it("sets the status code to 403", () => {
         errorhandler(err, req, res, next);
-        res.statusCode.should.equal(403);
+        expect(res.statusCode).toEqual(403);
       });
     });
 
@@ -195,31 +197,38 @@ describe("Error Handler", () => {
 
       it("redirects to the start page if the error contains no redirect location", () => {
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledOnce;
-        res.redirect.should.have.been.calledWith("/start");
-        res.render.should.not.have.been.called;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith("/start");
+        expect(res.render).not.toHaveBeenCalled();
       });
 
       it("redirects to a specific location if given", () => {
         err.redirect = "/redirect/step";
         errorhandler(err, req, res, next);
-        res.redirect.should.have.been.calledOnce;
-        res.redirect.should.have.been.calledWith("/redirect/step");
-        res.render.should.not.have.been.called;
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith("/redirect/step");
+        expect(res.render).not.toHaveBeenCalled();
       });
 
       it("shows error template if a custom template is given and no redirect location is specified", () => {
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        res.redirect.should.not.have.been.called;
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith("test/template");
+        expect(res.redirect).not.toHaveBeenCalled();
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
+          "test/template",
+          expect.objectContaining({
+            error: expect.objectContaining({
+              code: "MISSING_PREREQ",
+            }),
+          }),
+        );
       });
 
       it("sets the status code to 403", () => {
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        res.statusCode.should.equal(403);
+        expect(res.statusCode).toEqual(403);
       });
     });
 
@@ -233,50 +242,50 @@ describe("Error Handler", () => {
       it("should set status code to 403 for MISSING_AUTHPARAMS error", () => {
         err = { code: "MISSING_AUTHPARAMS" };
         errorhandler(err, req, res, next);
-        res.statusCode.should.equal(403);
+        expect(res.statusCode).toEqual(403);
       });
 
       it("sets a default template if no template is specified", () => {
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "errors/error",
-          sinon.match({ backLink: "/back" }),
+          expect.objectContaining({ backLink: "/back" }),
         );
       });
 
       it("doesn't overwrite a custom template", () => {
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        res.render.should.have.been.calledOnce;
-        res.render.should.have.been.calledWith(
+        expect(res.render).toHaveBeenCalledTimes(1);
+        expect(res.render).toHaveBeenCalledWith(
           "test/template",
-          sinon.match({ backLink: "/back" }),
+          expect.objectContaining({ backLink: "/back" }),
         );
       });
 
       it("should log the error if no template is specified", () => {
         errorhandler(err, req, res, next);
-        loggerModule.logError.should.have.been.calledOnce;
-        loggerModule.logError.should.have.been.calledWithExactly(req, err);
+        expect(loggerModule.logError).toHaveBeenCalledTimes(1);
+        expect(loggerModule.logError).toHaveBeenCalledWith(req, err);
       });
 
       it("should not log the error if a template is specified", () => {
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        loggerModule.logError.should.not.have.been.called;
+        expect(loggerModule.logError).not.toHaveBeenCalled();
       });
 
       it("should only log the error if the header has been sent", () => {
         res._headerSent = true;
         err.template = "test/template";
         errorhandler(err, req, res, next);
-        loggerModule.logError.should.have.been.calledOnce;
-        loggerModule.logError.should.have.been.calledWithExactly(req, err, {
+        expect(loggerModule.logError).toHaveBeenCalledTimes(1);
+        expect(loggerModule.logError).toHaveBeenCalledWith(req, err, {
           messagePrefix: "Error after response",
         });
-        res.render.should.not.have.been.called;
-        next.should.not.have.been.called;
+        expect(res.render).not.toHaveBeenCalled();
+        expect(next).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/bootstrap/middleware/spec.feature-flag.js
+++ b/test/bootstrap/middleware/spec.feature-flag.js
@@ -1,3 +1,5 @@
+import { describe, it, beforeEach, vi, expect } from "vitest";
+
 const featureFlag = require(
   APP_ROOT + "/src/bootstrap/middleware/feature-flag",
 );
@@ -29,8 +31,8 @@ describe("Feature Flag", () => {
     };
 
     res = require("hmpo-reqres").res();
-    res.redirect = sinon.stub();
-    next = sinon.stub();
+    res.redirect = vi.fn();
+    next = vi.fn();
 
     middleware = featureFlag.middleware(options);
   });
@@ -39,7 +41,7 @@ describe("Feature Flag", () => {
     it("should copy options.featureFlags and session.featureFlags to req.featureFlags", () => {
       middleware(req, res, next);
 
-      req.featureFlags.should.deep.equal({
+      expect(req.featureFlags).toEqual({
         enabledFlag: true,
         disabledFlag: false,
         flagFromConfig: true,
@@ -54,31 +56,31 @@ describe("Feature Flag", () => {
 
       middleware(req, res, next);
 
-      req.featureFlags.should.deep.equal({});
+      expect(req.featureFlags).toEqual({});
     });
 
     it("should deep clone featureFlags", () => {
       middleware(req, res, next);
 
-      req.featureFlags.should.not.equal(options.featureFlags);
-      req.featureFlags.should.not.equal(req.session.featureFlags);
+      expect(req.featureFlags).not.toEqual(options.featureFlags);
+      expect(req.featureFlags).not.toEqual(req.session.featureFlags);
       req.featureFlags.flagFromConfig = false;
-      options.featureFlags.flagFromConfig.should.be.true;
+      expect(options.featureFlags.flagFromConfig).toBe(true);
     });
 
     it("should keep existing object reference", () => {
       const originalFlags = { originalFlag: true };
       req.featureFlags = originalFlags;
       middleware(req, res, next);
-      req.featureFlags.should.equal(originalFlags);
-      req.featureFlags.originalFlag.should.be.true;
-      req.featureFlags.flagFromConfig.should.be.true;
+      expect(req.featureFlags).toEqual(originalFlags);
+      expect(req.featureFlags.originalFlag).toBe(true);
+      expect(req.featureFlags.flagFromConfig).toBe(true);
     });
 
     it("should set the res.locals.featureFlags object to the updated featureflags", () => {
       req.featureFlags = { originalFlag: true };
       middleware(req, res, next);
-      res.locals.featureFlags.should.deep.equal({
+      expect(res.locals.featureFlags).toEqual({
         originalFlag: true,
         flagFromConfig: true,
         flagFromSession: true,
@@ -87,13 +89,13 @@ describe("Feature Flag", () => {
 
     it("should call next with no arguments", () => {
       middleware(req, res, next);
-      next.should.have.been.calledWithExactly();
+      expect(next).toHaveBeenCalled();
     });
   });
 
   describe("#getFlags", () => {
     it("should return the current flags from the req", () => {
-      featureFlag.getFlags(req).should.deep.equal({
+      expect(featureFlag.getFlags(req)).toEqual({
         enabledFlag: true,
         disabledFlag: false,
       });
@@ -101,51 +103,51 @@ describe("Feature Flag", () => {
 
     it("should return en empty object if there are no flags in the req", () => {
       delete req.featureFlags;
-      featureFlag.getFlags(req).should.deep.equal({});
+      expect(featureFlag.getFlags(req)).toEqual({});
     });
 
     it("should not cache flag results", () => {
       req.featureFlags.varyingFlag = true;
 
       let flags = featureFlag.getFlags(req);
-      flags.varyingFlag.should.equal(true);
+      expect(flags.varyingFlag).toEqual(true);
 
       req.featureFlags.varyingFlag = false;
 
       flags = featureFlag.getFlags(req);
-      flags.varyingFlag.should.equal(false);
+      expect(flags.varyingFlag).toEqual(false);
     });
   });
 
   describe("#isEnabled", () => {
     it("should call getFlags to fetch the current flags from the req", () => {
-      featureFlag.isEnabled("enabledFlag", req).should.be.true;
+      expect(featureFlag.isEnabled("enabledFlag", req)).toBe(true);
     });
 
     it("should be true with an enabled flag", () => {
-      featureFlag.isEnabled("enabledFlag", req).should.be.true;
+      expect(featureFlag.isEnabled("enabledFlag", req)).toBe(true);
     });
 
     it("should be false with an disabled flag", () => {
-      featureFlag.isEnabled("disabledFlag", req).should.be.false;
+      expect(featureFlag.isEnabled("disabledFlag", req)).toBe(false);
     });
 
     it("should be false with a non existing flag", () => {
-      featureFlag.isEnabled("nonExistingFlag", req).should.be.false;
+      expect(featureFlag.isEnabled("nonExistingFlag", req)).toBe(false);
     });
   });
 
   describe("#isDisabled", () => {
     it("should be false with an enabled flag", () => {
-      featureFlag.isDisabled("enabledFlag", req).should.be.false;
+      expect(featureFlag.isDisabled("enabledFlag", req)).toBe(false);
     });
 
     it("should be true with an disabled flag", () => {
-      featureFlag.isDisabled("disabledFlag", req).should.be.true;
+      expect(featureFlag.isDisabled("disabledFlag", req)).toBe(true);
     });
 
     it("should be true with an non existing flag", () => {
-      featureFlag.isDisabled("nonExistingFlag", req).should.be.true;
+      expect(featureFlag.isDisabled("nonExistingFlag", req)).toBe(true);
     });
   });
 
@@ -156,7 +158,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      res.redirect.should.have.been.calledWith("http://example.org");
+      expect(res.redirect).toHaveBeenCalledWith("http://example.org");
     });
 
     it("should not call next with an enabled flag", () => {
@@ -165,7 +167,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      next.should.not.have.been.called;
+      expect(next).not.toHaveBeenCalled();
     });
 
     it("should not redirect with a disabled flag", () => {
@@ -174,7 +176,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      res.redirect.should.not.have.been.called;
+      expect(res.redirect).not.toHaveBeenCalled();
     });
 
     it("should call next with a disabled flag", () => {
@@ -183,7 +185,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      next.should.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
 
     it("should not redirect with a non existing flag", () => {
@@ -192,7 +194,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      res.redirect.should.not.have.been.called;
+      expect(res.redirect).not.toHaveBeenCalled();
     });
 
     it("should call next with a non existing flag", () => {
@@ -201,7 +203,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      next.should.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
   });
 
@@ -212,7 +214,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      res.redirect.should.not.have.been.called;
+      expect(res.redirect).not.toHaveBeenCalled();
     });
 
     it("should call next with an enabled flag", () => {
@@ -221,7 +223,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      next.should.have.been.called;
+      expect(next).toHaveBeenCalled();
     });
 
     it("should redirect with a disabled flag", () => {
@@ -230,7 +232,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      res.redirect.should.have.been.calledWith("http://example.org");
+      expect(res.redirect).toHaveBeenCalledWith("http://example.org");
     });
 
     it("should not call next with a disabled flag", () => {
@@ -239,7 +241,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      next.should.not.have.been.called;
+      expect(next).not.toHaveBeenCalled();
     });
 
     it("should redirect with a non existing flag", () => {
@@ -248,7 +250,7 @@ describe("Feature Flag", () => {
         "http://example.org",
       );
       middleware(req, res, next);
-      res.redirect.should.have.been.called;
+      expect(res.redirect).toHaveBeenCalled();
     });
 
     it("should not call next with a non existing flag", () => {
@@ -258,7 +260,7 @@ describe("Feature Flag", () => {
       );
       middleware(req, res, next);
 
-      next.should.not.have.been.called;
+      expect(next).not.toHaveBeenCalled();
     });
   });
 
@@ -266,8 +268,8 @@ describe("Feature Flag", () => {
     let ifMiddleware, elseMiddleware;
 
     beforeEach(() => {
-      ifMiddleware = sinon.stub();
-      elseMiddleware = sinon.stub();
+      ifMiddleware = vi.fn();
+      elseMiddleware = vi.fn();
     });
 
     it("should route to ifMiddleware with an enabled flag", () => {
@@ -279,8 +281,8 @@ describe("Feature Flag", () => {
 
       middleware(req, res, next);
 
-      ifMiddleware.should.have.been.calledWithExactly(req, res, next);
-      elseMiddleware.should.not.have.been.called;
+      expect(ifMiddleware).toHaveBeenCalledWith(req, res, next);
+      expect(elseMiddleware).not.toHaveBeenCalled();
     });
 
     it("should route to elseMiddleware with a disabled flag", () => {
@@ -292,8 +294,8 @@ describe("Feature Flag", () => {
 
       middleware(req, res, next);
 
-      elseMiddleware.should.have.been.calledWithExactly(req, res, next);
-      ifMiddleware.should.not.have.been.called;
+      expect(elseMiddleware).toHaveBeenCalledWith(req, res, next);
+      expect(ifMiddleware).not.toHaveBeenCalled();
     });
 
     it("should route to elseMiddleware with a non existing flag", () => {
@@ -305,8 +307,8 @@ describe("Feature Flag", () => {
 
       middleware(req, res, next);
 
-      elseMiddleware.should.have.been.calledWithExactly(req, res, next);
-      ifMiddleware.should.not.have.been.called;
+      expect(elseMiddleware).toHaveBeenCalledWith(req, res, next);
+      expect(ifMiddleware).not.toHaveBeenCalled();
     });
 
     it("should route to elseMiddleware with a no flag", () => {
@@ -314,8 +316,8 @@ describe("Feature Flag", () => {
 
       middleware(req, res, next);
 
-      elseMiddleware.should.have.been.calledWithExactly(req, res, next);
-      ifMiddleware.should.not.have.been.called;
+      expect(elseMiddleware).toHaveBeenCalledWith(req, res, next);
+      expect(ifMiddleware).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/bootstrap/middleware/spec.headers.js
+++ b/test/bootstrap/middleware/spec.headers.js
@@ -1,3 +1,5 @@
+import { describe, vi, it, expect, beforeEach } from "vitest";
+
 const proxyquire = require("proxyquire").noPreserveCache();
 
 describe("headers middleware", () => {
@@ -5,23 +7,23 @@ describe("headers middleware", () => {
 
   beforeEach(() => {
     app = {
-      disable: sinon.stub(),
-      set: sinon.stub(),
-      use: sinon.stub(),
+      disable: vi.fn(),
+      set: vi.fn(),
+      use: vi.fn(),
     };
 
     stubs = {
-      compression: sinon.stub().returns("compression middleware"),
+      compression: vi.fn().mockReturnValue("compression middleware"),
       nocache: {
-        middleware: sinon.stub().returns("nocache middleware"),
+        middleware: vi.fn().mockReturnValue("nocache middleware"),
       },
       compatibility: {
-        middleware: sinon.stub().returns("compatibility middleware"),
+        middleware: vi.fn().mockReturnValue("compatibility middleware"),
       },
-      helmet: sinon.stub(),
+      helmet: vi.fn(),
     };
 
-    stubs.helmet.frameguard = sinon.stub().returns("frameguard middleware");
+    stubs.helmet.frameguard = vi.fn().mockReturnValue("frameguard middleware");
 
     middleware = proxyquire(APP_ROOT + "/src/bootstrap/middleware/headers", {
       compression: stubs.compression,
@@ -31,15 +33,15 @@ describe("headers middleware", () => {
     });
   });
 
-  context("headers", () => {
+  describe("headers", () => {
     it("should enable trust proxy by default", () => {
       middleware.setup(app);
-      app.set.should.have.been.calledWithExactly("trust proxy", true);
+      expect(app.set).toHaveBeenCalledWith("trust proxy", true);
     });
 
     it("should set trust proxy to config setting", () => {
       middleware.setup(app, { trustProxy: ["loopback", "localunique"] });
-      app.set.should.have.been.calledWithExactly("trust proxy", [
+      expect(app.set).toHaveBeenCalledWith("trust proxy", [
         "loopback",
         "localunique",
       ]);
@@ -47,55 +49,53 @@ describe("headers middleware", () => {
 
     it("should use the nocache middleware", () => {
       middleware.setup(app);
-      stubs.nocache.middleware.should.have.been.calledWithExactly({
+      expect(stubs.nocache.middleware).toHaveBeenCalledWith({
         publicPath: "/public",
       });
-      app.use.should.have.been.calledWithExactly("nocache middleware");
+      expect(app.use).toHaveBeenCalledWith("nocache middleware");
     });
 
     it("should use the nocache middleware with options", () => {
       middleware.setup(app, { publicPath: "/static" });
-      stubs.nocache.middleware.should.have.been.calledWithExactly({
+      expect(stubs.nocache.middleware).toHaveBeenCalledWith({
         publicPath: "/static",
       });
-      app.use.should.have.been.calledWithExactly("nocache middleware");
+      expect(app.use).toHaveBeenCalledWith("nocache middleware");
     });
 
     it("should use the returned compression middleware", () => {
       middleware.setup(app);
-      stubs.compression.should.have.been.calledOnce;
-      stubs.compression.should.have.been.calledWithExactly();
-      app.use.should.have.been.calledWithExactly("compression middleware");
+      expect(stubs.compression).toHaveBeenCalledTimes(1);
+      expect(stubs.compression).toHaveBeenCalledWith();
+      expect(app.use).toHaveBeenCalledWith("compression middleware");
     });
 
     it("should not use the returned compression middleware if compression is disabled", () => {
       middleware.setup(app, { disableCompression: true });
-      stubs.compression.should.not.have.been.called;
-      app.use.should.not.have.been.calledWithExactly("compression middleware");
+      expect(stubs.compression).not.toHaveBeenCalled();
+      expect(app.use).not.toHaveBeenCalledWith("compression middleware");
     });
 
     it("should use the compatibility middleware", () => {
       middleware.setup(app);
-      stubs.compatibility.middleware.should.have.been.calledWithExactly();
-      app.use.should.have.been.calledWithExactly("compatibility middleware");
+      expect(stubs.compatibility.middleware).toHaveBeenCalledWith();
+      expect(app.use).toHaveBeenCalledWith("compatibility middleware");
     });
   });
 
-  context("security", () => {
+  describe("security", () => {
     describe("by default without helmet config", () => {
       it("should disable the x-powered-by header", () => {
         middleware.setup(app);
-        app.disable.should.have.been.calledWithExactly("x-powered-by");
+        expect(app.disable).toHaveBeenCalledWith("x-powered-by");
       });
 
       it("should use the returned frameguard middleware", () => {
         middleware.setup(app);
 
-        stubs.helmet.frameguard.should.have.been.calledOnce;
-        stubs.helmet.frameguard.should.have.been.calledWithExactly(
-          "sameorigin",
-        );
-        app.use.should.have.been.calledWithExactly("frameguard middleware");
+        expect(stubs.helmet.frameguard).toHaveBeenCalledTimes(1);
+        expect(stubs.helmet.frameguard).toHaveBeenCalledWith("sameorigin");
+        expect(app.use).toHaveBeenCalledWith("frameguard middleware");
       });
     });
 
@@ -111,20 +111,20 @@ describe("headers middleware", () => {
       it("should call helmet with config", () => {
         middleware.setup(app, { helmet: helmetConfig });
 
-        expect(stubs.helmet).to.have.been.calledWithExactly(helmetConfig);
+        expect(stubs.helmet).toHaveBeenCalledWith(helmetConfig);
       });
 
       it("should not directly disable the x-powered-by header", () => {
         middleware.setup(app, { helmet: helmetConfig });
 
-        app.disable.should.not.have.been.calledWithExactly("x-powered-by");
+        expect(app.disable).not.toHaveBeenCalledWith("x-powered-by");
       });
 
       it("should not directly use the returned frameguard middleware", () => {
         middleware.setup(app, { helmet: helmetConfig });
 
-        stubs.helmet.frameguard.should.not.have.been.called;
-        app.use.should.not.have.been.calledWithExactly("frameguard middleware");
+        expect(stubs.helmet.frameguard).not.toHaveBeenCalled();
+        expect(app.use).not.toHaveBeenCalledWith("frameguard middleware");
       });
     });
   });

--- a/test/bootstrap/middleware/spec.healthcheck.js
+++ b/test/bootstrap/middleware/spec.healthcheck.js
@@ -1,3 +1,5 @@
+import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
+
 const healthcheck = require(APP_ROOT + "/src/bootstrap/middleware/healthcheck");
 const os = require("os");
 
@@ -14,19 +16,19 @@ describe("healthcheck", () => {
       },
     };
     res = {
-      setHeader: sinon.stub(),
-      status: sinon.stub(),
-      json: sinon.stub(),
+      setHeader: vi.fn(),
+      status: vi.fn(),
+      json: vi.fn(),
     };
-    res.setHeader.returns(res);
-    res.status.returns(res);
-    res.json.returns(res);
-    sinon.stub(os, "hostname").returns("myhostname");
+    res.setHeader.mockReturnValue(res);
+    res.status.mockReturnValue(res);
+    res.json.mockReturnValue(res);
+    vi.spyOn(os, "hostname").mockReturnValue("myhostname");
     delete process.env.pm_id;
   });
 
   afterEach(() => {
-    os.hostname.restore();
+    os.hostname.mockRestore();
     if (originalPmId) {
       process.env.pm_id = originalPmId;
     } else {
@@ -37,18 +39,18 @@ describe("healthcheck", () => {
   it("should set Connection header to close", () => {
     healthcheck.middleware()(req, res);
 
-    res.setHeader.should.have.been.calledWithExactly("Connection", "close");
+    expect(res.setHeader).toHaveBeenCalledWith("Connection", "close");
   });
 
   it("should return a 200 status", () => {
     healthcheck.middleware()(req, res);
 
-    res.status.should.have.been.calledWithExactly(200);
-    res.json.should.have.been.calledWithExactly(
-      sinon.match({
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
         appName: "test",
         id: "myhostname",
-        uptime: sinon.match.number,
+        uptime: expect.any(Number),
         version: "1.0.1",
         status: "OK",
       }),
@@ -64,12 +66,12 @@ describe("healthcheck", () => {
     };
     healthcheck.middleware({ healthFn })(req, res);
 
-    res.status.should.have.been.calledWithExactly(500);
-    res.json.should.have.been.calledWithExactly(
-      sinon.match({
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
         appName: "test",
         id: "myhostname",
-        uptime: sinon.match.number,
+        uptime: expect.any(Number),
         version: "1.0.1",
         error: {
           code: "ERROR",
@@ -88,12 +90,12 @@ describe("healthcheck", () => {
     };
     healthcheck.middleware({ healthFn })(req, res);
 
-    res.status.should.have.been.calledWithExactly(500);
-    res.json.should.have.been.calledWithExactly(
-      sinon.match({
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
         appName: "test",
         id: "myhostname",
-        uptime: sinon.match.number,
+        uptime: expect.any(Number),
         version: "1.0.1",
         error: {
           message: "An error",
@@ -103,29 +105,29 @@ describe("healthcheck", () => {
     );
   });
 
-  it("should run async healthFn with status information", (done) => {
+  it("should run async healthFn with status information", async () => {
     const healthFn = async () => {
       const error = new Error("An error");
       error.code = "ERROR";
       throw error;
     };
     healthcheck.middleware({ healthFn })(req, res);
-    setTimeout(() => {
-      res.status.should.have.been.calledWithExactly(500);
-      res.json.should.have.been.calledWithExactly(
-        sinon.match({
-          id: "myhostname",
-          uptime: sinon.match.number,
-          version: "1.0.1",
-          error: {
-            code: "ERROR",
-            message: "An error",
-          },
-          status: "ERROR",
-        }),
-      );
-      done();
+
+    await vi.waitFor(() => {
+      expect(res.status).toHaveBeenCalledWith(500);
     });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "myhostname",
+        uptime: expect.any(Number),
+        version: "1.0.1",
+        error: {
+          code: "ERROR",
+          message: "An error",
+        },
+        status: "ERROR",
+      }),
+    );
   });
 
   it("should append pm id to id if present", () => {
@@ -133,8 +135,8 @@ describe("healthcheck", () => {
 
     healthcheck.middleware()(req, res);
 
-    res.json.should.have.been.calledWithExactly(
-      sinon.match({
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
         id: "myhostname-1",
       }),
     );

--- a/test/bootstrap/middleware/spec.index.js
+++ b/test/bootstrap/middleware/spec.index.js
@@ -1,3 +1,5 @@
+import { describe, it, vi, beforeEach, expect } from "vitest";
+
 const path = require("path");
 const proxyquire = require("proxyquire").noPreserveCache();
 const hmpoComponentsDir = path.dirname(require.resolve("hmpo-components"));
@@ -8,42 +10,42 @@ describe("middleware functions", () => {
   beforeEach(() => {
     app = {
       locals: { existing: "local" },
-      set: sinon.stub(),
-      enable: sinon.stub(),
-      disable: sinon.stub(),
-      engine: sinon.stub(),
-      use: sinon.stub(),
-      get: sinon.stub(),
-      listen: sinon.stub().yields(),
+      set: vi.fn(),
+      enable: vi.fn(),
+      disable: vi.fn(),
+      engine: vi.fn(),
+      use: vi.fn(),
+      get: vi.fn(),
+      listen: vi.fn(),
     };
   });
 
   it("exports middleware functions", () => {
     middleware = require(APP_ROOT + "/src/bootstrap/middleware");
-    middleware.setup.should.be.a("function");
-    middleware.session.should.be.a("function");
-    middleware.errorHandler.should.be.a("function");
-    middleware.listen.should.be.a("function");
+    expect(typeof middleware.setup).toBe("function");
+    expect(typeof middleware.session).toBe("function");
+    expect(typeof middleware.errorHandler).toBe("function");
+    expect(typeof middleware.listen).toBe("function");
   });
 
   describe("requiredArgument", () => {
     it("should throw an error when the required argument is not provided in session", () => {
-      expect(() => middleware.session()).to.throw(
-        Error,
+      expect(() => middleware.session()).toThrow(Error);
+      expect(() => middleware.session()).toThrow(
         "Argument 'app' must be specified",
       );
     });
 
     it("should throw an error when the required argument is not provided in errorHandler", () => {
-      expect(() => middleware.errorHandler()).to.throw(
-        Error,
+      expect(() => middleware.errorHandler()).toThrow(Error);
+      expect(() => middleware.errorHandler()).toThrow(
         "Argument 'app' must be specified",
       );
     });
 
     it("should throw an error when the required argument is not provided in listen", () => {
-      expect(() => middleware.listen()).to.throw(
-        Error,
+      expect(() => middleware.listen()).toThrow(Error);
+      expect(() => middleware.listen()).toThrow(
         "Argument 'app' must be specified",
       );
     });
@@ -54,43 +56,44 @@ describe("middleware functions", () => {
 
     beforeEach(() => {
       nunjucksEnv = {};
+      vi.stubEnv("NODE_ENV", "development");
       stubs = {
-        express: sinon.stub().returns(app),
+        express: vi.fn().mockReturnValue(app),
         hmpoLogger: {
-          middleware: sinon.stub().returns("hmpoLogger middleware"),
+          middleware: vi.fn().mockReturnValue("hmpoLogger middleware"),
         },
         bodyParser: {
-          urlencoded: sinon.stub().returns("bodyParser middleware"),
+          urlencoded: vi.fn().mockReturnValue("bodyParser middleware"),
         },
         cookies: {
-          middleware: sinon.stub().returns("cookies middleware"),
+          middleware: vi.fn().mockReturnValue("cookies middleware"),
         },
         headers: {
-          setup: sinon.stub().returns({}),
+          setup: vi.fn().mockReturnValue({}),
         },
         healthcheck: {
-          middleware: sinon.stub().returns("healthcheck middleware"),
+          middleware: vi.fn().mockReturnValue("healthcheck middleware"),
         },
         version: {
-          middleware: sinon.stub().returns("version middleware"),
+          middleware: vi.fn().mockReturnValue("version middleware"),
         },
         featureFlag: {
-          middleware: sinon.stub().returns("featureFlag middleware"),
+          middleware: vi.fn().mockReturnValue("featureFlag middleware"),
         },
         modelOptions: {
-          middleware: sinon.stub().returns("modelOptions middleware"),
+          middleware: vi.fn().mockReturnValue("modelOptions middleware"),
         },
         public: {
-          middleware: sinon.stub().returns("public middleware"),
+          middleware: vi.fn().mockReturnValue("public middleware"),
         },
         nunjucks: {
-          setup: sinon.stub().returns(nunjucksEnv),
+          setup: vi.fn().mockReturnValue(nunjucksEnv),
         },
         translation: {
-          setup: sinon.stub(),
+          setup: vi.fn(),
         },
         hmpoComponents: {
-          setup: sinon.stub(),
+          setup: vi.fn(),
         },
       };
 
@@ -122,8 +125,8 @@ describe("middleware functions", () => {
         requestLogging: false,
         stubs,
       });
-      expect(stubs.hmpoLogger.middleware).to.not.have.been.called;
-      expect(app.use).to.not.have.been.calledWith("hmpoLogger middleware");
+      expect(stubs.hmpoLogger.middleware).not.toHaveBeenCalled();
+      expect(app.use).not.toHaveBeenCalledWith("hmpoLogger middleware");
     });
 
     it("should use the public middleware when publicOptions is true or not set", () => {
@@ -136,7 +139,7 @@ describe("middleware functions", () => {
         public: { maxAge: 3600 }, // publicOptions is set
       });
 
-      stubs.public.middleware.should.have.been.calledWithExactly({
+      expect(stubs.public.middleware).toHaveBeenCalledWith({
         urls: {
           public: "/public-url",
           publicImages: "/public-url/images",
@@ -148,7 +151,7 @@ describe("middleware functions", () => {
         public: { maxAge: 3600 },
         hmpoComponentsDir,
       });
-      app.use.should.have.been.calledWithExactly("public middleware");
+      expect(app.use).toHaveBeenCalledWith("public middleware");
     });
 
     it("should not use public middleware when publicOptions is false", () => {
@@ -164,8 +167,8 @@ describe("middleware functions", () => {
         public: publicOptions,
       });
 
-      stubs.public.middleware.should.not.have.been.called;
-      app.use.should.not.have.been.calledWith("public middleware");
+      expect(stubs.public.middleware).not.toHaveBeenCalled();
+      expect(app.use).not.toHaveBeenCalledWith("public middleware");
     });
 
     it("should set default version and healthcheck URLs if not provided", () => {
@@ -173,8 +176,8 @@ describe("middleware functions", () => {
 
       middleware.setup({ urls });
 
-      expect(urls.version).to.equal("/version");
-      expect(urls.healthcheck).to.equal("/healthcheck");
+      expect(urls.version).toEqual("/version");
+      expect(urls.healthcheck).toEqual("/healthcheck");
     });
 
     it("should retain provided version and healthcheck URLs", () => {
@@ -185,39 +188,36 @@ describe("middleware functions", () => {
 
       middleware.setup({ urls });
 
-      expect(urls.version).to.equal("/custom-version");
-      expect(urls.healthcheck).to.equal("/custom-healthcheck");
+      expect(urls.version).toEqual("/custom-version");
+      expect(urls.healthcheck).toEqual("/custom-healthcheck");
     });
 
     it("should create a new express app", () => {
       const returnedApp = middleware.setup();
-      stubs.express.should.have.been.calledWithExactly();
-      returnedApp.should.equal(app);
+      expect(stubs.express).toHaveBeenCalledWith();
+      expect(returnedApp).toEqual(app);
     });
 
     it("should set the express env value", () => {
       middleware.setup();
-      app.set.should.have.been.calledWithExactly("env", "development");
+      expect(app.set).toHaveBeenCalledWith("env", "development");
     });
 
     it("should use the env value specified in options", () => {
       middleware.setup({ env: "production" });
-      app.set.should.have.been.calledWithExactly("env", "production");
+      expect(app.set).toHaveBeenCalledWith("env", "production");
     });
 
     it("should use the /version middleware", () => {
       middleware.setup();
-      stubs.version.middleware.should.have.been.calledWithExactly();
-      app.get.should.have.been.calledWithExactly(
-        "/version",
-        "version middleware",
-      );
+      expect(stubs.version.middleware).toHaveBeenCalledWith();
+      expect(app.get).toHaveBeenCalledWith("/version", "version middleware");
     });
 
     it("should not use the /version middleware", () => {
       middleware.setup({ urls: { version: false } });
-      stubs.version.middleware.should.not.have.been.called;
-      app.get.should.not.have.been.calledWithExactly(
+      expect(stubs.version.middleware).not.toHaveBeenCalled();
+      expect(app.get).not.toHaveBeenCalledWith(
         "/version",
         "version middleware",
       );
@@ -225,8 +225,8 @@ describe("middleware functions", () => {
 
     it("should use the /healthcheck middleware", () => {
       middleware.setup();
-      stubs.healthcheck.middleware.should.have.been.calledWithExactly();
-      app.get.should.have.been.calledWithExactly(
+      expect(stubs.healthcheck.middleware).toHaveBeenCalledWith();
+      expect(app.get).toHaveBeenCalledWith(
         "/healthcheck",
         "healthcheck middleware",
       );
@@ -234,8 +234,8 @@ describe("middleware functions", () => {
 
     it("should not use the /healthcheck middleware", () => {
       middleware.setup({ urls: { healthcheck: false } });
-      stubs.healthcheck.middleware.should.not.have.been.called;
-      app.get.should.not.have.been.calledWithExactly(
+      expect(stubs.healthcheck.middleware).not.toHaveBeenCalled();
+      expect(app.get).not.toHaveBeenCalledWith(
         "/healthcheck",
         "healthcheck middleware",
       );
@@ -250,7 +250,7 @@ describe("middleware functions", () => {
         publicImagesDirs: ["assets/images"],
         public: { maxAge: 3600 },
       });
-      stubs.public.middleware.should.have.been.calledWithExactly({
+      expect(stubs.public.middleware).toHaveBeenCalledWith({
         urls: {
           public: "/public-url",
           publicImages: "/public-url/images",
@@ -262,54 +262,52 @@ describe("middleware functions", () => {
         public: { maxAge: 3600 },
         hmpoComponentsDir,
       });
-      app.use.should.have.been.calledWithExactly("public middleware");
+      expect(app.use).toHaveBeenCalledWith("public middleware");
     });
 
     it("should use the hmpoLogger middleware", () => {
       middleware.setup();
-      stubs.hmpoLogger.middleware.should.have.been.calledWithExactly(
-        ":request",
-      );
-      app.use.should.have.been.calledWithExactly("hmpoLogger middleware");
+      expect(stubs.hmpoLogger.middleware).toHaveBeenCalledWith(":request");
+      expect(app.use).toHaveBeenCalledWith("hmpoLogger middleware");
     });
 
     it("should use the modelOptions middleware", () => {
       middleware.setup({ modelOptions: { sessionIDHeader: "ID" } });
-      stubs.modelOptions.middleware.should.have.been.calledWithExactly({
+      expect(stubs.modelOptions.middleware).toHaveBeenCalledWith({
         sessionIDHeader: "ID",
       });
-      app.use.should.have.been.calledWithExactly("modelOptions middleware");
+      expect(app.use).toHaveBeenCalledWith("modelOptions middleware");
     });
 
     it("should use the feature flag setup middleware", () => {
       middleware.setup({
         featureFlags: { testFeature: true },
       });
-      stubs.featureFlag.middleware.should.have.been.calledWithExactly({
+      expect(stubs.featureFlag.middleware).toHaveBeenCalledWith({
         featureFlags: { testFeature: true },
       });
-      app.use.should.have.been.calledWithExactly("featureFlag middleware");
+      expect(app.use).toHaveBeenCalledWith("featureFlag middleware");
     });
 
     it("should use the cookies middleware", () => {
       middleware.setup({ cookies: { secret: "test" } });
-      stubs.cookies.middleware.should.have.been.calledWithExactly({
+      expect(stubs.cookies.middleware).toHaveBeenCalledWith({
         secret: "test",
       });
-      app.use.should.have.been.calledWithExactly("cookies middleware");
+      expect(app.use).toHaveBeenCalledWith("cookies middleware");
     });
 
     it("should use the body parser middleware", () => {
       middleware.setup();
-      stubs.bodyParser.urlencoded.should.have.been.calledWithExactly({
+      expect(stubs.bodyParser.urlencoded).toHaveBeenCalledWith({
         extended: true,
       });
-      app.use.should.have.been.calledWithExactly("bodyParser middleware");
+      expect(app.use).toHaveBeenCalledWith("bodyParser middleware");
     });
 
     it("should setup nunjucks", () => {
       middleware.setup({ views: "a/dir", nunjucks: { additional: "options" } });
-      stubs.nunjucks.setup.should.have.been.calledWithExactly(app, {
+      expect(stubs.nunjucks.setup).toHaveBeenCalledWith(app, {
         views: "a/dir",
         hmpoComponentsDir,
         additional: "options",
@@ -321,7 +319,7 @@ describe("middleware functions", () => {
         locales: "a/dir",
         translation: { additional: "options" },
       });
-      stubs.translation.setup.should.have.been.calledWithExactly(app, {
+      expect(stubs.translation.setup).toHaveBeenCalledWith(app, {
         locales: "a/dir",
         hmpoComponentsDir,
         additional: "options",
@@ -330,7 +328,7 @@ describe("middleware functions", () => {
 
     it("should not setup translation when no locales or translation options are provided", () => {
       middleware.setup({});
-      stubs.translation.setup.should.not.have.been.called;
+      expect(stubs.translation.setup).not.toHaveBeenCalled();
     });
 
     it("should setup headers", () => {
@@ -341,7 +339,7 @@ describe("middleware functions", () => {
         helmet: { referrerPolicy: { policy: "no-referrer" } },
       });
 
-      stubs.headers.setup.should.have.been.calledWithExactly(app, {
+      expect(stubs.headers.setup).toHaveBeenCalledWith(app, {
         disableCompression: true,
         trustProxy: ["localhost"],
         publicPath: "/static",
@@ -351,17 +349,14 @@ describe("middleware functions", () => {
 
     it("should setup hmpoComponents", () => {
       middleware.setup();
-      stubs.hmpoComponents.setup.should.have.been.calledWithExactly(
-        app,
-        nunjucksEnv,
-      );
+      expect(stubs.hmpoComponents.setup).toHaveBeenCalledWith(app, nunjucksEnv);
     });
 
     it("should set the globals", () => {
       middleware.setup({
         urls: { foo: "bar" },
       });
-      app.locals.should.deep.equal({
+      expect(app.locals).toEqual({
         existing: "local",
         baseUrl: "/",
         assetPath: "/public",
@@ -377,9 +372,9 @@ describe("middleware functions", () => {
     it("should set res.locals.baseUrl to req.baseUrl during middleware setup", () => {
       const req = { baseUrl: "/test-url" };
       const res = { locals: {} };
-      const next = sinon.stub();
+      const next = vi.fn();
 
-      app.use.callsFake((middlewareFunction) => {
+      app.use.mockImplementation((middlewareFunction) => {
         if (middlewareFunction.length === 3) {
           middlewareFunction(req, res, next);
         }
@@ -387,8 +382,8 @@ describe("middleware functions", () => {
 
       middleware.setup();
 
-      expect(res.locals.baseUrl).to.equal("/test-url");
-      expect(next.calledOnce).to.be.true;
+      expect(res.locals.baseUrl).toEqual("/test-url");
+      expect(next).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -398,13 +393,13 @@ describe("middleware functions", () => {
     beforeEach(() => {
       stubs = {
         session: {
-          middleware: sinon.stub().returns("session middleware"),
+          middleware: vi.fn().mockReturnValue("session middleware"),
         },
         featureFlag: {
-          middleware: sinon.stub().returns("featureFlag middleware"),
+          middleware: vi.fn().mockReturnValue("featureFlag middleware"),
         },
         linkedFiles: {
-          middleware: sinon.stub().returns("linkedFiles middleware"),
+          middleware: vi.fn().mockReturnValue("linkedFiles middleware"),
         },
       };
 
@@ -417,24 +412,24 @@ describe("middleware functions", () => {
 
     it("should use session middleware", () => {
       middleware.session(app, { secret: "qwerty" });
-      stubs.session.middleware.should.have.been.calledWithExactly({
+      expect(stubs.session.middleware).toHaveBeenCalledWith({
         secret: "qwerty",
       });
-      app.use.should.have.been.calledWithExactly("session middleware");
+      expect(app.use).toHaveBeenCalledWith("session middleware");
     });
 
     it("should use the feature flag setup middleware", () => {
       middleware.session(app);
-      stubs.featureFlag.middleware.should.have.been.calledWithExactly();
-      app.use.should.have.been.calledWithExactly("featureFlag middleware");
+      expect(stubs.featureFlag.middleware).toHaveBeenCalledWith();
+      expect(app.use).toHaveBeenCalledWith("featureFlag middleware");
     });
 
     it("should use the linked files middleware", () => {
       middleware.session(app, { ttl: 10 });
-      stubs.linkedFiles.middleware.should.have.been.calledWithExactly({
+      expect(stubs.linkedFiles.middleware).toHaveBeenCalledWith({
         ttl: 10,
       });
-      app.use.should.have.been.calledWithExactly("linkedFiles middleware");
+      expect(app.use).toHaveBeenCalledWith("linkedFiles middleware");
     });
   });
 
@@ -444,10 +439,10 @@ describe("middleware functions", () => {
     beforeEach(() => {
       stubs = {
         pageNotFound: {
-          middleware: sinon.stub().returns("pageNotFound middleware"),
+          middleware: vi.fn().mockReturnValue("pageNotFound middleware"),
         },
         errorHandler: {
-          middleware: sinon.stub().returns("errorHandler middleware"),
+          middleware: vi.fn().mockReturnValue("errorHandler middleware"),
         },
       };
 
@@ -459,18 +454,18 @@ describe("middleware functions", () => {
 
     it("should use the pageNotFound middleware", () => {
       middleware.errorHandler(app, { foo: "bar" });
-      stubs.pageNotFound.middleware.should.have.been.calledWithExactly({
+      expect(stubs.pageNotFound.middleware).toHaveBeenCalledWith({
         foo: "bar",
       });
-      app.use.should.have.been.calledWithExactly("pageNotFound middleware");
+      expect(app.use).toHaveBeenCalledWith("pageNotFound middleware");
     });
 
     it("should use the errorHandler middleware", () => {
       middleware.errorHandler(app, { foo: "bar" });
-      stubs.errorHandler.middleware.should.have.been.calledWithExactly({
+      expect(stubs.errorHandler.middleware).toHaveBeenCalledWith({
         foo: "bar",
       });
-      app.use.should.have.been.calledWithExactly("errorHandler middleware");
+      expect(app.use).toHaveBeenCalledWith("errorHandler middleware");
     });
   });
 
@@ -481,12 +476,20 @@ describe("middleware functions", () => {
 
     it("should listen on the default host and port", () => {
       middleware.listen(app);
-      app.listen.should.have.been.calledWith(3000, "0.0.0.0");
+      expect(app.listen).toHaveBeenCalledWith(
+        3000,
+        "0.0.0.0",
+        expect.any(Function),
+      );
     });
 
     it("should listen on the specified host and port", () => {
       middleware.listen(app, { host: "hostname", port: 8888 });
-      app.listen.should.have.been.calledWith(8888, "hostname");
+      expect(app.listen).toHaveBeenCalledWith(
+        8888,
+        "hostname",
+        expect.any(Function),
+      );
     });
   });
 });

--- a/test/bootstrap/middleware/spec.linked-files.js
+++ b/test/bootstrap/middleware/spec.linked-files.js
@@ -179,7 +179,7 @@ describe("Linked Files", () => {
     it("should remove the linked file id from the session", () => {
       req.session.linkedFiles = { foo: true, [testuuid]: true };
       linkedFiles.del(req, testuuid, cb);
-      req.session.linkedFiles = { foo: true };
+      expect(req.session.linkedFiles).toEqual({ foo: true });
     });
   });
 

--- a/test/bootstrap/middleware/spec.linked-files.js
+++ b/test/bootstrap/middleware/spec.linked-files.js
@@ -1,3 +1,5 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
 const redisClient = require(APP_ROOT + "/src/bootstrap/lib/redis-client");
 const linkedFiles = require(
   APP_ROOT + "/src/bootstrap/middleware/linked-files",
@@ -14,153 +16,164 @@ describe("Linked Files", () => {
   let cb;
 
   beforeEach(() => {
+    vi.resetModules();
     redisStub = {
-      del: sinon.stub().yields(),
-      expire: sinon.stub(),
-      get: sinon.stub().yields(null, "S:data"),
-      setex: sinon.stub().yields(null),
+      del: vi.fn((id, callback) => callback()),
+      expire: vi.fn(),
+      get: vi.fn((id, callback) => callback(null, "S:data")),
+      setex: vi.fn((id, ttl, data, callback) => callback(null)),
     };
-    sinon.stub(redisClient, "getClient").returns(redisStub);
-    sinon.stub(uuid, "v4").returns(testuuid);
+    vi.spyOn(redisClient, "getClient").mockReturnValue(redisStub);
+    vi.spyOn(uuid, "v4").mockReturnValue(testuuid);
     req = { session: {} };
     res = {
       finished: true,
       statusCode: 200,
     };
-    next = sinon.stub();
-    cb = sinon.stub();
+    next = vi.fn();
+    cb = vi.fn();
   });
 
   afterEach(() => {
-    redisClient.getClient.restore();
-    uuid.v4.restore();
+    redisClient.getClient.mockRestore();
+    uuid.v4.mockRestore();
   });
 
   it("exports an object of middleware", () => {
-    linkedFiles.should.be.an("object");
+    expect(typeof linkedFiles).toBe("object");
   });
 
   describe("add", () => {
     it("should call callback with redis error", () => {
       let err = new Error();
-      redisStub.setex.yields(err);
+      redisStub.setex.mockImplementationOnce((id, ttl, data, callback) =>
+        callback(err),
+      );
       linkedFiles.add(req, 1800, "abc", cb);
-      cb.should.have.been.calledWithExactly(err);
+      expect(cb).toHaveBeenCalledWith(err);
     });
 
     it("should add the data file into redis", () => {
       linkedFiles.add(req, 1800, "abc", cb);
-      redisStub.setex.should.have.been.calledWithExactly(
+      expect(redisStub.setex).toHaveBeenCalledWith(
         "file:" + testuuid,
         1800,
         "S:abc",
-        sinon.match.func,
+        expect.any(Function),
       );
     });
 
     it("should add an object as JSON", () => {
       linkedFiles.add(req, 1800, { foo: "bar" }, cb);
-      redisStub.setex.should.have.been.calledWithExactly(
+      expect(redisStub.setex).toHaveBeenCalledWith(
         "file:" + testuuid,
         1800,
         'J:{"foo":"bar"}',
-        sinon.match.func,
+        expect.any(Function),
       );
     });
 
     it("should add a buffer as base64", () => {
       linkedFiles.add(req, 1800, Buffer.from("abcd", "ascii"), cb);
-      redisStub.setex.should.have.been.calledWithExactly(
+      expect(redisStub.setex).toHaveBeenCalledWith(
         "file:" + testuuid,
         1800,
         "B:YWJjZA==",
-        sinon.match.func,
+        expect.any(Function),
       );
     });
 
     it("should add id into the session file list", () => {
       linkedFiles.add(req, 1800, "abc", cb);
-      req.session.linkedFiles.should.contain.key(testuuid);
+      expect(req.session.linkedFiles).toHaveProperty(testuuid);
     });
 
     it("should call the callback with an id", () => {
       linkedFiles.add(req, 1800, "abc", cb);
-      cb.should.have.been.calledWithExactly(null, testuuid);
+      expect(cb).toHaveBeenCalledWith(null, testuuid);
     });
   });
 
   describe("get", () => {
     it("should call callback with error if the id is not found", () => {
       linkedFiles.get(req, testuuid, cb);
-      cb.should.have.been.calledWithExactly(sinon.match.instanceOf(Error));
+      expect(cb).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it("should call callback with redis error", () => {
       req.session.linkedFiles = { [testuuid]: true };
       let err = new Error();
-      redisStub.get.yields(err);
+      redisStub.get.mockImplementationOnce((id, callback) => {
+        callback(err);
+      });
       linkedFiles.get(req, testuuid, cb);
-      cb.should.have.been.calledWithExactly(err);
+      expect(cb).toHaveBeenCalledWith(err);
     });
 
     it("should get a string data file from redis by id", () => {
       req.session.linkedFiles = { [testuuid]: true };
       linkedFiles.get(req, testuuid, cb);
-      redisStub.get.should.have.been.calledWithExactly(
+      expect(redisStub.get).toHaveBeenCalledWith(
         "file:" + testuuid,
-        sinon.match.func,
+        expect.any(Function),
       );
-      cb.should.have.been.calledWithExactly(null, "data");
+      expect(cb).toHaveBeenCalledWith(null, "data");
     });
 
     it("should get a json data file from redis by id", () => {
       req.session.linkedFiles = { [testuuid]: true };
-      redisStub.get.yields(null, 'J:{"foo":"bar"}');
+      redisStub.get.mockImplementationOnce((id, callback) => {
+        callback(null, 'J:{"foo":"bar"}');
+      });
       linkedFiles.get(req, testuuid, cb);
-      redisStub.get.should.have.been.calledWithExactly(
+      expect(redisStub.get).toHaveBeenCalledWith(
         "file:" + testuuid,
-        sinon.match.func,
+        expect.any(Function),
       );
-      cb.should.have.been.calledWithExactly(null, { foo: "bar" });
+      expect(cb).toHaveBeenCalledWith(null, { foo: "bar" });
     });
 
     it("should call callback with an error if the json is invalid", () => {
       req.session.linkedFiles = { [testuuid]: true };
-      redisStub.get.yields(null, 'J:{"foo":aaaaa}');
+      redisStub.get.mockImplementationOnce((id, callback) => {
+        callback(null, 'J:{"foo":aaaaa}');
+      });
       linkedFiles.get(req, testuuid, cb);
-      redisStub.get.should.have.been.calledWithExactly(
+      expect(redisStub.get).toHaveBeenCalledWith(
         "file:" + testuuid,
-        sinon.match.func,
+        expect.any(Function),
       );
-      cb.should.have.been.calledWithExactly(sinon.match.instanceOf(Error));
+      expect(cb).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it("should get a buffer data file from redis by id", () => {
       req.session.linkedFiles = { [testuuid]: true };
-      redisStub.get.yields(null, "B:YWJjZA==");
+      redisStub.get.mockImplementationOnce((id, callback) => {
+        callback(null, "B:YWJjZA==");
+      });
       linkedFiles.get(req, testuuid, cb);
-      redisStub.get.should.have.been.calledWithExactly(
+      expect(redisStub.get).toHaveBeenCalledWith(
         "file:" + testuuid,
-        sinon.match.func,
+        expect.any(Function),
       );
-      cb.should.have.been.calledWithExactly(null, Buffer.from("abcd"));
+      expect(cb).toHaveBeenCalledWith(null, Buffer.from("abcd"));
     });
   });
 
   describe("del", () => {
     it("should call callback with error if the id is not found", () => {
       linkedFiles.del(req, testuuid, cb);
-      cb.should.have.been.calledWithExactly(sinon.match.instanceOf(Error));
+      expect(cb).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it("should get the data file from redis by id", () => {
       req.session.linkedFiles = { [testuuid]: true };
       linkedFiles.del(req, testuuid, cb);
-      redisStub.del.should.have.been.calledWithExactly(
+      expect(redisStub.del).toHaveBeenCalledWith(
         "file:" + testuuid,
-        sinon.match.func,
+        expect.any(Function),
       );
-      cb.should.have.been.calledWithExactly();
+      expect(cb).toHaveBeenCalled();
     });
 
     it("should remove the linked file id from the session", () => {
@@ -172,53 +185,48 @@ describe("Linked Files", () => {
 
   describe("middleware", () => {
     it("should be a function", () => {
-      linkedFiles.middleware.should.be.a("function");
+      expect(typeof linkedFiles.middleware).toBe("function");
     });
 
     it("should call next", () => {
       linkedFiles.middleware()(req, res, next);
-      next.should.have.been.calledWithExactly();
+      expect(next).toHaveBeenCalled();
     });
 
     describe("should add curried functions into the req object", () => {
       beforeEach(() => {
-        sinon.stub(linkedFiles, "add");
-        sinon.stub(linkedFiles, "get");
-        sinon.stub(linkedFiles, "del");
+        vi.spyOn(linkedFiles, "add");
+        vi.spyOn(linkedFiles, "get");
+        vi.spyOn(linkedFiles, "del");
         linkedFiles.middleware()(req, res, next);
       });
 
       afterEach(() => {
-        linkedFiles.add.restore();
-        linkedFiles.get.restore();
-        linkedFiles.del.restore();
+        linkedFiles.add.mockRestore();
+        linkedFiles.get.mockRestore();
+        linkedFiles.del.mockRestore();
       });
 
       it("#add", () => {
-        req.linkedFiles.add.should.be.a("function");
+        expect(typeof req.linkedFiles.add).toBe("function");
         req.linkedFiles.add("abcd", cb);
-        linkedFiles.add.should.have.been.calledWithExactly(
-          req,
-          30000,
-          "abcd",
-          cb,
-        );
+        expect(linkedFiles.add).toHaveBeenCalledWith(req, 30000, "abcd", cb);
       });
 
       it("#get", () => {
-        req.linkedFiles.get.should.be.a("function");
+        expect(typeof req.linkedFiles.get).toBe("function");
         req.linkedFiles.get(testuuid, cb);
-        linkedFiles.get.should.have.been.calledWithExactly(req, testuuid, cb);
+        expect(linkedFiles.get).toHaveBeenCalledWith(req, testuuid, cb);
       });
 
       it("#del", () => {
-        req.linkedFiles.del.should.be.a("function");
+        expect(typeof req.linkedFiles.del).toBe("function");
         req.linkedFiles.del(testuuid, cb);
-        linkedFiles.del.should.have.been.calledWithExactly(req, testuuid, cb);
+        expect(linkedFiles.del).toHaveBeenCalledWith(req, testuuid, cb);
       });
     });
 
-    it("should call redis expire for each file in the session", (done) => {
+    it("should call redis expire for each file in the session", async () => {
       req.session.linkedFiles = {
         123: true,
         456: true,
@@ -226,15 +234,14 @@ describe("Linked Files", () => {
 
       linkedFiles.middleware({ ttl: 1800 })(req, res, next);
 
-      setImmediate(() => {
-        redisStub.expire.should.have.been.calledTwice;
-        redisStub.expire.should.have.been.calledWithExactly("file:123", 1800);
-        redisStub.expire.should.have.been.calledWithExactly("file:456", 1800);
-        done();
+      await vi.waitFor(() => {
+        expect(redisStub.expire).toHaveBeenCalledTimes(3);
       });
+      expect(redisStub.expire).toHaveBeenCalledWith("file:123", 1800);
+      expect(redisStub.expire).toHaveBeenCalledWith("file:456", 1800);
     });
 
-    it("should call not call expire if the session has been removed", (done) => {
+    it("should call not call expire if the session has been removed", () => {
       req.session.linkedFiles = {
         123: true,
         456: true,
@@ -245,17 +252,15 @@ describe("Linked Files", () => {
       delete req.session;
 
       setImmediate(() => {
-        redisStub.expire.should.not.have.been.called;
-        done();
+        expect(redisStub.expire).not.toHaveBeenCalled();
       });
     });
 
-    it("should not extend any expiry times if there are no linked files", (done) => {
+    it("should not extend any expiry times if there are no linked files", () => {
       linkedFiles.middleware({ ttl: 1800 })(req, res, next);
 
       setImmediate(() => {
-        redisStub.expire.should.not.have.been.called;
-        done();
+        expect(redisStub.expire).not.toHaveBeenCalled();
       });
     });
   });
@@ -267,16 +272,21 @@ describe("Linked Files", () => {
       BaseClass = class {
         middlewareDecodePayload() {}
       };
-      sinon.stub(BaseClass.prototype, "middlewareDecodePayload").yields();
+      vi.spyOn(
+        BaseClass.prototype,
+        "middlewareDecodePayload",
+      ).mockImplementation((req, res, callback) => {
+        callback();
+      });
     });
 
     it("should be a function", () => {
-      linkedFiles.injection.should.be.a("function");
+      expect(typeof linkedFiles.injection).toBe("function");
     });
 
     it("should throw an error if an invalid argument is passed", () => {
       let EmptyClass = class {};
-      expect(() => linkedFiles.injection(EmptyClass)).to.throw(
+      expect(() => linkedFiles.injection(EmptyClass)).toThrow(
         "SessionInjection base class expected",
       );
     });
@@ -285,8 +295,8 @@ describe("Linked Files", () => {
       let InjectionClass = linkedFiles.injection(BaseClass);
       let instance = new InjectionClass();
 
-      InjectionClass.should.not.equal(BaseClass);
-      instance.should.be.an.instanceOf(BaseClass);
+      expect(InjectionClass).not.toEqual(BaseClass);
+      expect(instance).toBeInstanceOf(BaseClass);
     });
 
     describe("#middlewareDecodePayload", () => {
@@ -295,35 +305,41 @@ describe("Linked Files", () => {
       beforeEach(() => {
         let InjectionClass = linkedFiles.injection(BaseClass);
         instance = new InjectionClass();
-        sinon.stub(linkedFiles, "add").yields(null, "abc123");
+        vi.spyOn(linkedFiles, "add").mockImplementation(
+          (req, res, callback) => {
+            callback(null, "abc123");
+          },
+        );
       });
 
       afterEach(() => {
-        linkedFiles.add.restore();
+        linkedFiles.add.mockRestore();
       });
 
       it("should call parent method", () => {
         instance.middlewareDecodePayload(req, res, next);
 
-        BaseClass.prototype.middlewareDecodePayload.should.have.been.calledWithExactly(
-          req,
-          res,
-          sinon.match.func,
-        );
+        expect(
+          BaseClass.prototype.middlewareDecodePayload,
+        ).toHaveBeenCalledWith(req, res, expect.any(Function));
       });
 
       it("should call next with an error if parent returns an error", () => {
         let err = new Error();
-        BaseClass.prototype.middlewareDecodePayload.yields(err);
+        BaseClass.prototype.middlewareDecodePayload.mockImplementation(
+          (req, res, callback) => {
+            callback(err);
+          },
+        );
         instance.middlewareDecodePayload(req, res, next);
-        next.should.have.been.calledWithExactly(err);
+        expect(next).toHaveBeenCalledWith(err);
       });
 
       it("should call next if no payload files are specified", () => {
         req.payload = {};
         instance.middlewareDecodePayload(req, res, next);
-        next.should.have.been.calledWithExactly();
-        linkedFiles.add.should.not.have.been.called;
+        expect(next).toHaveBeenCalled();
+        expect(linkedFiles.add).not.toHaveBeenCalled();
       });
 
       it("should create payload.journeyKeys if it does not exist", () => {
@@ -331,7 +347,7 @@ describe("Linked Files", () => {
           files: {},
         };
         instance.middlewareDecodePayload(req, res, next);
-        req.payload.journeyKeys.should.eql({});
+        expect(req.payload.journeyKeys).toEqual({});
       });
 
       it("should add each file specified in payload.files", () => {
@@ -342,16 +358,16 @@ describe("Linked Files", () => {
           },
         };
         instance.middlewareDecodePayload(req, res, next);
-        linkedFiles.add.should.have.been.calledTwice;
-        linkedFiles.add.should.have.been.calledWithExactly(
+        expect(linkedFiles.add).toHaveBeenCalledTimes(2);
+        expect(linkedFiles.add).toHaveBeenCalledWith(
           req,
           "testdata",
-          sinon.match.func,
+          expect.any(Function),
         );
-        linkedFiles.add.should.have.been.calledWithExactly(
+        expect(linkedFiles.add).toHaveBeenCalledWith(
           req,
           { json: "data" },
-          sinon.match.func,
+          expect.any(Function),
         );
       });
 
@@ -364,7 +380,7 @@ describe("Linked Files", () => {
           },
         };
         instance.middlewareDecodePayload(req, res, next);
-        req.payload.journeyKeys.should.eql({
+        expect(req.payload.journeyKeys).toEqual({
           foo: "bar",
           first: "abc123",
           second: "abc123",
@@ -373,14 +389,16 @@ describe("Linked Files", () => {
 
       it("should call next with any linkedFiles error", () => {
         let err = new Error();
-        linkedFiles.add.yields(err);
+        linkedFiles.add.mockImplementation((req, res, callback) => {
+          callback(err);
+        });
         req.payload = {
           files: {
             first: "testdata",
           },
         };
         instance.middlewareDecodePayload(req, res, next);
-        next.should.have.been.calledWithExactly(err);
+        expect(next).toHaveBeenCalledWith(err);
       });
     });
   });

--- a/test/bootstrap/middleware/spec.model.options.js
+++ b/test/bootstrap/middleware/spec.model.options.js
@@ -1,3 +1,5 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
 const modelOptions = require(
   APP_ROOT + "/src/bootstrap/middleware/model-options",
 );
@@ -13,23 +15,23 @@ describe("Model options helper", () => {
       },
     };
     res = {};
-    next = sinon.stub();
+    next = vi.fn();
   });
 
   describe("middleware", () => {
     it("exports a function with length 3", () => {
-      modelOptions.middleware().should.be.a("function");
-      modelOptions.middleware().should.have.a.lengthOf(3);
+      expect(typeof modelOptions.middleware()).toBe("function");
+      expect(modelOptions.middleware()).toHaveLength(3);
     });
 
     it("creates a modelOptions method in req", () => {
       modelOptions.middleware()(req, res, next);
-      req.modelOptions.should.be.a("function");
+      expect(typeof req.modelOptions).toBe("function");
     });
 
     it("calls next", () => {
       modelOptions.middleware()(req, res, next);
-      next.should.have.been.calledWithExactly();
+      expect(next).toHaveBeenCalled();
     });
   });
 
@@ -37,7 +39,7 @@ describe("Model options helper", () => {
     it("returns model options", () => {
       modelOptions.middleware()(req, res, next);
       let options = req.modelOptions();
-      options.should.deep.equal({
+      expect(options).toEqual({
         headers: {
           "X-SESSION-ID": "SESSION",
           "X-SCENARIO-ID": "SCENARIO",
@@ -58,7 +60,7 @@ describe("Model options helper", () => {
         headers: { extra: "value", "X-SCENARIO-ID": "other" },
         logging: { key: "value" },
       });
-      options.should.deep.equal({
+      expect(options).toEqual({
         headers: {
           HEADER1: "SESSION",
           HEADER2: "SCENARIO",

--- a/test/bootstrap/middleware/spec.nocache.js
+++ b/test/bootstrap/middleware/spec.nocache.js
@@ -1,9 +1,11 @@
+import { describe, vi, it, expect } from "vitest";
+
 const nocache = require(APP_ROOT + "/src/bootstrap/middleware/nocache");
 
 describe("No Cache", () => {
   it("exports a middleware function", () => {
-    nocache.middleware().should.be.a("function");
-    nocache.middleware().length.should.equal(3);
+    expect(typeof nocache.middleware()).toBe("function");
+    expect(nocache.middleware()).toHaveLength(3);
   });
 
   describe("middleware", () => {
@@ -12,31 +14,29 @@ describe("No Cache", () => {
         path: "/a/path",
       };
       let res = {
-        setHeader: sinon.stub(),
+        setHeader: vi.fn(),
       };
-      let next = sinon.stub();
+      let next = vi.fn();
 
       nocache.middleware()(req, res, next);
 
-      res.setHeader.should.have.been.called;
-      res.setHeader
-        .getCall(0)
-        .should.have.been.calledWithExactly("Surrogate-Control", "no-store");
-      res.setHeader
-        .getCall(1)
-        .should.have.been.calledWithExactly(
-          "Cache-Control",
-          "no-store, no-cache, must-revalidate, proxy-revalidate",
-        );
-      res.setHeader
-        .getCall(2)
-        .should.have.been.calledWithExactly("Pragma", "no-cache");
-      res.setHeader
-        .getCall(3)
-        .should.have.been.calledWithExactly("Expires", "0");
+      expect(res.setHeader).toHaveBeenCalled();
+      expect(res.setHeader).toHaveBeenNthCalledWith(
+        1,
+        "Surrogate-Control",
+        "no-store",
+      );
 
-      next.should.have.been.calledOnce;
-      next.should.have.been.calledWithExactly();
+      expect(res.setHeader).toHaveBeenNthCalledWith(
+        2,
+        "Cache-Control",
+        "no-store, no-cache, must-revalidate, proxy-revalidate",
+      );
+      expect(res.setHeader).toHaveBeenNthCalledWith(3, "Pragma", "no-cache");
+      expect(res.setHeader).toHaveBeenNthCalledWith(4, "Expires", "0");
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
 
     it("should not set no cache headers for a public URL", () => {
@@ -44,15 +44,15 @@ describe("No Cache", () => {
         path: "/a/path/public/foo/bar",
       };
       let res = {
-        setHeader: sinon.stub(),
+        setHeader: vi.fn(),
       };
-      let next = sinon.stub();
+      let next = vi.fn();
 
       nocache.middleware({ publicPath: "/public" })(req, res, next);
 
-      res.setHeader.should.not.have.been.called;
-      next.should.have.been.calledOnce;
-      next.should.have.been.calledWithExactly();
+      expect(res.setHeader).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
   });
 });

--- a/test/bootstrap/middleware/spec.nunjucks.js
+++ b/test/bootstrap/middleware/spec.nunjucks.js
@@ -1,3 +1,5 @@
+import { describe, vi, expect, it, beforeEach, afterEach } from "vitest";
+
 const nunjucks = require("nunjucks");
 const { setup: setupNunjucks } = require(
   APP_ROOT + "/src/bootstrap/middleware/nunjucks",
@@ -8,24 +10,24 @@ describe("nunjucks middleware", () => {
 
   beforeEach(() => {
     app = {
-      set: sinon.stub(),
-      get: sinon.stub(),
+      set: vi.fn(),
+      get: vi.fn(),
     };
-    app.get.withArgs("dev").returns(true);
+    app.get.mockReturnValue(true);
 
-    sinon.stub(nunjucks, "configure");
+    vi.spyOn(nunjucks, "configure");
     nunjucksEnv = {};
-    nunjucksEnv.addGlobal = sinon.stub();
-    nunjucks.configure.returns(nunjucksEnv);
+    nunjucksEnv.addGlobal = vi.fn();
+    nunjucks.configure.mockReturnValue(nunjucksEnv);
   });
 
   afterEach(() => {
-    nunjucks.configure.restore();
+    nunjucks.configure.mockRestore();
   });
 
   it("should configure nunjucks with a default set of views and options", () => {
     setupNunjucks(app);
-    nunjucks.configure.should.have.been.calledWithExactly(
+    expect(nunjucks.configure).toHaveBeenCalledWith(
       [
         APP_ROOT + "/test/bootstrap/fixtures/views",
         APP_ROOT + "/node_modules/govuk-frontend/dist",
@@ -43,34 +45,34 @@ describe("nunjucks middleware", () => {
   it("should configure nunjucks with hmpo-components views when hmpoComponentsDir is provided", () => {
     const hmpoComponentsDir = APP_ROOT + "/node_modules/hmpo-components";
     setupNunjucks(app, { hmpoComponentsDir });
-    nunjucks.configure.should.have.been.calledWithExactly(
+    expect(nunjucks.configure).toHaveBeenCalledWith(
       [
         APP_ROOT + "/test/bootstrap/fixtures/views",
         APP_ROOT + "/node_modules/hmpo-components/components",
         APP_ROOT + "/node_modules/govuk-frontend/dist",
         APP_ROOT + "/node_modules/@govuk-one-login",
       ],
-      sinon.match.object,
+      expect.any(Object),
     );
   });
 
   it("should filter out a view if not present", () => {
     setupNunjucks(app, { views: ["views", "not_found"] });
-    nunjucks.configure.should.have.been.calledWithExactly(
+    expect(nunjucks.configure).toHaveBeenCalledWith(
       [
         APP_ROOT + "/test/bootstrap/fixtures/views",
         APP_ROOT + "/node_modules/govuk-frontend/dist",
         APP_ROOT + "/node_modules/@govuk-one-login",
       ],
-      sinon.match.object,
+      expect.any(Object),
     );
   });
 
   it("should run in prod mode if dev flag not set", () => {
-    app.get.withArgs("dev").returns(false);
+    app.get.mockReturnValue(false);
 
     setupNunjucks(app);
-    nunjucks.configure.should.have.been.calledWithExactly(sinon.match.array, {
+    expect(nunjucks.configure).toHaveBeenCalledWith(expect.any(Array), {
       express: app,
       dev: false,
       noCache: false,
@@ -80,11 +82,11 @@ describe("nunjucks middleware", () => {
 
   it("should set the view engine value", () => {
     setupNunjucks(app);
-    app.set.should.have.been.calledWithExactly("view engine", "html");
+    expect(app.set).toHaveBeenCalledWith("view engine", "html");
   });
 
   it("should set the Nunjucks environment", () => {
     const result = setupNunjucks(app);
-    result.should.equal(nunjucksEnv);
+    expect(result).toEqual(nunjucksEnv);
   });
 });

--- a/test/bootstrap/middleware/spec.page-not-found.js
+++ b/test/bootstrap/middleware/spec.page-not-found.js
@@ -1,3 +1,5 @@
+import { describe, it, vi, expect, beforeEach } from "vitest";
+
 const pageNotFound = require(
   APP_ROOT + "/src/bootstrap/middleware/page-not-found",
 ).middleware;
@@ -8,30 +10,30 @@ describe("Page Not Found", () => {
   beforeEach(() => {
     req = {};
     res = {};
-    cb = sinon.stub();
+    cb = vi.fn();
   });
 
   describe("middleware", () => {
     it("exports a function with length 3", () => {
-      pageNotFound().should.be.a("function");
-      pageNotFound().length.should.equal(3);
+      expect(typeof pageNotFound()).toBe("function");
+      expect(pageNotFound()).toHaveLength(3);
     });
 
     it("called callback with an error", () => {
       pageNotFound()(req, res, cb);
-      cb.should.have.been.calledOnce;
-      cb.should.have.been.calledWithExactly(sinon.match.instanceOf(Error));
-      const err = cb.getCall(0).args[0];
-      err.message.should.equal("Page not found");
-      err.code.should.equal("PAGE_NOT_FOUND");
-      err.template.should.equal("errors/page-not-found");
-      err.status.should.equal(404);
+      expect(cb).toHaveBeenCalledTimes(1);
+      const err = cb.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toEqual("Page not found");
+      expect(err.code).toEqual("PAGE_NOT_FOUND");
+      expect(err.template).toEqual("errors/page-not-found");
+      expect(err.status).toEqual(404);
     });
 
     it("use custom error template view", () => {
       pageNotFound({ pageNotFoundView: "test" })(req, res, cb);
-      const err = cb.getCall(0).args[0];
-      err.template.should.equal("test");
+      const err = cb.mock.calls[0][0];
+      expect(err.template).toEqual("test");
     });
   });
 });

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -1,6 +1,11 @@
 const publicModule = require(APP_ROOT + "/src/bootstrap/middleware/public");
 const publicMiddleware = publicModule.middleware;
 const notFoundFallback = publicModule.notFoundFallback;
+import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
+
+const publicMiddleware = require(
+  APP_ROOT + "/src/bootstrap/middleware/public",
+).middleware;
 const express = require("express");
 
 describe("Public static assets", () => {
@@ -8,22 +13,22 @@ describe("Public static assets", () => {
 
   beforeEach(() => {
     router = {
-      use: sinon.stub(),
+      use: vi.fn(),
     };
-    sinon.stub(express, "Router").returns(router);
-    sinon.stub(express, "static").returns("static middleware");
+    vi.spyOn(express, "Router").mockReturnValue(router);
+    vi.spyOn(express, "static").mockReturnValue("static middleware");
   });
 
   afterEach(() => {
-    express.Router.restore();
-    express.static.restore();
+    express.Router.mockRestore();
+    express.static.mockRestore();
   });
 
   describe("middleware", () => {
     it("creates and returns a router", () => {
       const router = publicMiddleware();
-      express.Router.should.have.been.called;
-      router.should.equal(router);
+      expect(express.Router).toHaveBeenCalled();
+      expect(router).toEqual(router);
     });
 
     it("adds default public directories", () => {
@@ -31,29 +36,31 @@ describe("Public static assets", () => {
 
       express.static.should.have.callCount(3);
       router.use.should.have.callCount(3);
+      expect(express.static).toHaveBeenCalledTimes(3);
+      expect(router.use).toHaveBeenCalledTimes(5);
 
-      router.use
-        .getCall(0)
-        .should.have.been.calledWithExactly("/public", "static middleware");
-      express.static
-        .getCall(0)
-        .should.have.been.calledWithExactly(
-          APP_ROOT + "/test/bootstrap/fixtures/public",
-          { maxAge: 86400000 },
-        );
+      expect(router.use).toHaveBeenNthCalledWith(
+        1,
+        "/public",
+        "static middleware",
+      );
 
-      router.use
-        .getCall(1)
-        .should.have.been.calledWithExactly(
-          "/public/images",
-          "static middleware",
-        );
-      express.static
-        .getCall(1)
-        .should.have.been.calledWithExactly(
-          APP_ROOT + "/test/bootstrap/fixtures/assets/images",
-          { maxAge: 86400000 },
-        );
+      expect(express.static).toHaveBeenNthCalledWith(
+        1,
+        APP_ROOT + "/test/bootstrap/fixtures/public",
+        { maxAge: 86400000 },
+      );
+
+      expect(router.use).toHaveBeenNthCalledWith(
+        2,
+        "/public/images",
+        "static middleware",
+      );
+      expect(express.static).toHaveBeenNthCalledWith(
+        2,
+        APP_ROOT + "/test/bootstrap/fixtures/assets/images",
+        { maxAge: 86400000 },
+      );
 
       router.use
         .getCall(2)
@@ -64,6 +71,27 @@ describe("Public static assets", () => {
           APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
           { maxAge: 86400000 },
         );
+      expect(router.use).toHaveBeenNthCalledWith(
+        3,
+        "/public",
+        "static middleware",
+      );
+      expect(express.static).toHaveBeenNthCalledWith(
+        3,
+        APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
+        { maxAge: 86400000 },
+      );
+
+      expect(router.use).toHaveBeenNthCalledWith(
+        4,
+        "/public",
+        expect.any(Function),
+      );
+      expect(router.use).toHaveBeenNthCalledWith(
+        5,
+        "/public/images",
+        expect.any(Function),
+      );
     });
 
     it("adds hmpo-components assets when hmpoComponentsDir is provided", () => {
@@ -75,19 +103,19 @@ describe("Public static assets", () => {
 
       express.static.should.have.callCount(4);
       router.use.should.have.callCount(4);
+      expect(express.static).toHaveBeenCalledTimes(4);
+      expect(router.use).toHaveBeenCalledTimes(6);
 
-      router.use
-        .getCall(2)
-        .should.have.been.calledWithExactly(
-          "/public/images",
-          "static middleware",
-        );
-      express.static
-        .getCall(2)
-        .should.have.been.calledWithExactly(
-          hmpoComponentsDir + "/assets/images",
-          { maxAge: 86400000 },
-        );
+      expect(router.use).toHaveBeenNthCalledWith(
+        3,
+        "/public/images",
+        "static middleware",
+      );
+      expect(express.static).toHaveBeenNthCalledWith(
+        3,
+        hmpoComponentsDir + "/assets/images",
+        { maxAge: 86400000 },
+      );
     });
   });
 

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -3,9 +3,6 @@ const publicMiddleware = publicModule.middleware;
 const notFoundFallback = publicModule.notFoundFallback;
 import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
 
-const publicMiddleware = require(
-  APP_ROOT + "/src/bootstrap/middleware/public",
-).middleware;
 const express = require("express");
 
 describe("Public static assets", () => {
@@ -34,10 +31,10 @@ describe("Public static assets", () => {
     it("adds default public directories", () => {
       const router = publicMiddleware();
 
-      express.static.should.have.callCount(3);
-      router.use.should.have.callCount(3);
+      // expect(express.static).should.have.callCount(3);
+      // router.use.should.have.callCount(3);
       expect(express.static).toHaveBeenCalledTimes(3);
-      expect(router.use).toHaveBeenCalledTimes(5);
+      expect(router.use).toHaveBeenCalledTimes(3);
 
       expect(router.use).toHaveBeenNthCalledWith(
         1,
@@ -62,15 +59,6 @@ describe("Public static assets", () => {
         { maxAge: 86400000 },
       );
 
-      router.use
-        .getCall(2)
-        .should.have.been.calledWithExactly("/public", "static middleware");
-      express.static
-        .getCall(2)
-        .should.have.been.calledWithExactly(
-          APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
-          { maxAge: 86400000 },
-        );
       expect(router.use).toHaveBeenNthCalledWith(
         3,
         "/public",
@@ -81,17 +69,6 @@ describe("Public static assets", () => {
         APP_ROOT + "/node_modules/govuk-frontend/dist/govuk/assets",
         { maxAge: 86400000 },
       );
-
-      expect(router.use).toHaveBeenNthCalledWith(
-        4,
-        "/public",
-        expect.any(Function),
-      );
-      expect(router.use).toHaveBeenNthCalledWith(
-        5,
-        "/public/images",
-        expect.any(Function),
-      );
     });
 
     it("adds hmpo-components assets when hmpoComponentsDir is provided", () => {
@@ -101,10 +78,8 @@ describe("Public static assets", () => {
       );
       publicMiddleware({ hmpoComponentsDir });
 
-      express.static.should.have.callCount(4);
-      router.use.should.have.callCount(4);
       expect(express.static).toHaveBeenCalledTimes(4);
-      expect(router.use).toHaveBeenCalledTimes(6);
+      expect(router.use).toHaveBeenCalledTimes(4);
 
       expect(router.use).toHaveBeenNthCalledWith(
         3,
@@ -125,13 +100,17 @@ describe("Public static assets", () => {
         urls: { public: "/public", publicImages: "/public/images" },
       });
 
-      router.use.should.have.callCount(2);
-      router.use
-        .getCall(0)
-        .should.have.been.calledWith("/public", sinon.match.func);
-      router.use
-        .getCall(1)
-        .should.have.been.calledWith("/public/images", sinon.match.func);
+      expect(router.use).toHaveBeenCalledTimes(2);
+      expect(router.use).toHaveBeenNthCalledWith(
+        1,
+        "/public",
+        expect.any(Function),
+      );
+      expect(router.use).toHaveBeenNthCalledWith(
+        2,
+        "/public/images",
+        expect.any(Function),
+      );
     });
 
     it("responds with 404 for unmatched requests", () => {
@@ -139,12 +118,12 @@ describe("Public static assets", () => {
         urls: { public: "/public", publicImages: "/public/images" },
       });
 
-      const [, handler] = router.use.getCall(0).args;
+      const [, handler] = router.use.mock.calls[0];
       const req = { url: "/i-dont-exist" };
-      const res = { sendStatus: sinon.stub() };
+      const res = { sendStatus: vi.fn() };
       handler(req, res);
 
-      res.sendStatus.should.have.been.calledWithExactly(404);
+      expect(res.sendStatus).toHaveBeenCalledWith(404);
     });
   });
 });

--- a/test/bootstrap/middleware/spec.public.js
+++ b/test/bootstrap/middleware/spec.public.js
@@ -31,8 +31,6 @@ describe("Public static assets", () => {
     it("adds default public directories", () => {
       const router = publicMiddleware();
 
-      // expect(express.static).should.have.callCount(3);
-      // router.use.should.have.callCount(3);
       expect(express.static).toHaveBeenCalledTimes(3);
       expect(router.use).toHaveBeenCalledTimes(3);
 

--- a/test/bootstrap/middleware/spec.session.js
+++ b/test/bootstrap/middleware/spec.session.js
@@ -1,3 +1,5 @@
+import { describe, vi, it, afterEach, beforeEach, expect } from "vitest";
+
 const session = require(APP_ROOT + "/src/bootstrap/middleware/session");
 const redisClient = require(APP_ROOT + "/src/bootstrap/lib/redis-client");
 
@@ -6,41 +8,41 @@ describe("Session", () => {
 
   beforeEach(() => {
     redisStub = {
-      on: sinon.stub(),
+      on: vi.fn(),
     };
-    sinon.stub(redisClient, "getClient").returns(redisStub);
+    vi.spyOn(redisClient, "getClient").mockReturnValue(redisStub);
   });
 
   afterEach(() => {
-    redisClient.getClient.restore();
+    redisClient.getClient.mockRestore();
   });
 
   it("exports an object of middleware", () => {
-    session.should.be.an("object");
+    expect(typeof session).toBe("object");
   });
 
   describe("session middleware", () => {
     it("should get the redis client", () => {
       session.middleware();
-      redisClient.getClient.should.have.been.calledOnce;
+      expect(redisClient.getClient).toHaveBeenCalledTimes(1);
     });
 
     it("should not create a redis session store if a store is specified", () => {
       const sessionStore = {
-        on: sinon.stub(),
+        on: vi.fn(),
       };
       session.middleware({ sessionStore });
-      redisClient.getClient.should.not.have.been.called;
+      expect(redisClient.getClient).not.toHaveBeenCalled();
     });
 
     it("should return a new session store", () => {
       const middleware = session.middleware();
-      middleware[0].should.be.a("function");
+      expect(typeof middleware[0]).toBe("function");
     });
   });
 
   describe("session locals", () => {
-    let req, res, next, clock;
+    let req, res, next;
 
     beforeEach(() => {
       req = {
@@ -51,24 +53,26 @@ describe("Session", () => {
       res = {
         locals: {},
       };
-      next = sinon.stub();
-      clock = sinon.useFakeTimers(1234567890);
+      next = vi.fn();
+      vi.useFakeTimers();
+      vi.setSystemTime(1234567890);
     });
 
     afterEach(() => {
-      clock.restore();
+      vi.useRealTimers();
     });
 
     it("should be a middleware function", () => {
-      session.middleware()[1].should.be.a("function").and.have.length(3);
+      expect(typeof session.middleware()[1]).toBe("function");
+      expect(session.middleware()[1]).toHaveLength(3);
     });
 
     it("should set new browser flag to true if no sesssion cookie exists", () => {
       session.middleware()[1](req, res, next);
 
-      req.isNewBrowser.should.be.true;
-      next.should.have.been.calledOnce;
-      next.should.have.been.calledWithExactly();
+      expect(req.isNewBrowser).toBe(true);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
 
     it("should set new browser flag to false if there is a session cookie", () => {
@@ -76,25 +80,25 @@ describe("Session", () => {
 
       session.middleware()[1](req, res, next);
 
-      req.isNewBrowser.should.be.false;
-      next.should.have.been.calledOnce;
-      next.should.have.been.calledWithExactly();
+      expect(req.isNewBrowser).toBe(false);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
 
     it("should set the session start time", () => {
       session.middleware()[1](req, res, next);
-      req.session["start-time"].should.equal(1234567890);
+      expect(req.session["start-time"]).toEqual(1234567890);
     });
 
     it("should set not overwrite an existing session start time", () => {
       req.session["start-time"] = 987654321;
       session.middleware()[1](req, res, next);
-      req.session["start-time"].should.equal(987654321);
+      expect(req.session["start-time"]).toEqual(987654321);
     });
 
     it("should set the session id to locals", () => {
       session.middleware()[1](req, res, next);
-      res.locals.sessionid.should.equal("abc123");
+      expect(res.locals.sessionid).toEqual("abc123");
     });
   });
 });

--- a/test/bootstrap/middleware/spec.session.session-store.js
+++ b/test/bootstrap/middleware/spec.session.session-store.js
@@ -1,5 +1,7 @@
+import { describe, vi, it, expect, beforeEach, afterEach } from "vitest";
+
 const proxyquire = require("proxyquire");
-const expressSession = sinon.stub();
+const expressSession = vi.fn();
 const session = proxyquire(APP_ROOT + "/src/bootstrap/middleware/session", {
   "express-session": expressSession,
 });
@@ -10,18 +12,18 @@ describe("Session", () => {
 
   beforeEach(() => {
     redisStub = {
-      on: sinon.stub(),
+      on: vi.fn(),
     };
-    sinon.stub(redisClient, "getClient").returns(redisStub);
-    expressSession.reset();
+    vi.spyOn(redisClient, "getClient").mockReturnValue(redisStub);
+    expressSession.mockReset();
   });
 
   afterEach(() => {
-    redisClient.getClient.restore();
+    redisClient.getClient.mockRestore();
   });
 
   it("exports an object of middleware", () => {
-    session.should.be.an("object");
+    expect(typeof session).toBe("object");
   });
 
   describe("session middleware", () => {
@@ -29,14 +31,14 @@ describe("Session", () => {
       let sessionStore;
       beforeEach(() => {
         sessionStore = {
-          on: sinon.stub(),
+          on: vi.fn(),
         };
       });
 
       it("should be set with default properties", () => {
         session.middleware({ sessionStore });
 
-        expect(expressSession).to.have.been.calledWith({
+        expect(expressSession).toHaveBeenCalledWith({
           store: sessionStore,
           cookie: { secure: "auto" },
           key: "hmpo.sid",
@@ -49,8 +51,8 @@ describe("Session", () => {
       it("should allow override of cookie key", () => {
         session.middleware({ cookieName: "cookie-name", sessionStore });
 
-        expect(expressSession).to.have.been.calledWith(
-          sinon.match({
+        expect(expressSession).toHaveBeenCalledWith(
+          expect.objectContaining({
             key: "cookie-name",
           }),
         );
@@ -59,14 +61,14 @@ describe("Session", () => {
       it("should allow override of secret", () => {
         session.middleware({ secret: "very-secret", sessionStore });
 
-        expect(expressSession).to.have.been.calledWith(
-          sinon.match({
+        expect(expressSession).toHaveBeenCalledWith(
+          expect.objectContaining({
             secret: "very-secret",
           }),
         );
       });
 
-      context("with cookieOptions", () => {
+      describe("with cookieOptions", () => {
         let cookieOptions;
 
         it("should add additional properties", () => {
@@ -76,9 +78,9 @@ describe("Session", () => {
 
           session.middleware({ cookieOptions, sessionStore });
 
-          expect(expressSession).to.have.been.calledWith(
-            sinon.match({
-              cookie: { domain: ".example.com" },
+          expect(expressSession).toHaveBeenCalledWith(
+            expect.objectContaining({
+              cookie: expect.objectContaining({ domain: ".example.com" }),
             }),
           );
         });
@@ -90,8 +92,8 @@ describe("Session", () => {
 
           session.middleware({ cookieOptions, sessionStore });
 
-          expect(expressSession).to.have.been.calledWith(
-            sinon.match({
+          expect(expressSession).toHaveBeenCalledWith(
+            expect.objectContaining({
               cookie: { secure: "false" },
             }),
           );
@@ -104,9 +106,9 @@ describe("Session", () => {
 
           session.middleware({ cookieOptions, sessionStore });
 
-          expect(expressSession).to.have.been.calledWith(
-            sinon.match({
-              cookie: { secure: "auto" },
+          expect(expressSession).toHaveBeenCalledWith(
+            expect.objectContaining({
+              cookie: expect.objectContaining({ secure: "auto" }),
             }),
           );
         });

--- a/test/bootstrap/middleware/spec.translation.js
+++ b/test/bootstrap/middleware/spec.translation.js
@@ -1,3 +1,5 @@
+import { describe, vi, it, expect, afterEach, beforeEach } from "vitest";
+
 const translation = require(APP_ROOT + "/src/bootstrap/middleware/translation");
 const i18n = require("hmpo-i18n");
 
@@ -6,20 +8,23 @@ describe("translation middleware", () => {
 
   beforeEach(() => {
     app = {
-      get: sinon.stub(),
+      use: vi.fn(),
+      get: vi.fn(),
     };
-    app.get.withArgs("dev").returns(true);
+    app.get.mockImplementation((arg) => {
+      if (arg === "dev") return true;
+    });
 
-    sinon.stub(i18n, "middleware");
+    vi.spyOn(i18n, "middleware");
   });
 
   afterEach(() => {
-    i18n.middleware.restore();
+    i18n.middleware.mockRestore();
   });
 
   it("should use the i18n middleware specifying the app root as the baseDir", () => {
     translation.setup(app);
-    i18n.middleware.should.have.been.calledWithExactly(app, {
+    expect(i18n.middleware).toHaveBeenCalledWith(app, {
       baseDir: [APP_ROOT + "/test/bootstrap/fixtures"],
       noCache: true,
       watch: true,
@@ -33,7 +38,7 @@ describe("translation middleware", () => {
     translation.setup(app, {
       hmpoComponentsDir: APP_ROOT + "/node_modules/hmpo-components",
     });
-    i18n.middleware.should.have.been.calledWithExactly(app, {
+    expect(i18n.middleware).toHaveBeenCalledWith(app, {
       baseDir: [
         APP_ROOT + "/test/bootstrap/fixtures",
         APP_ROOT + "/node_modules/hmpo-components",
@@ -48,7 +53,7 @@ describe("translation middleware", () => {
 
   it("should use the i18n middleware specifying a custom locales locations", () => {
     translation.setup(app, { locales: [".", "./dir_not_found"] });
-    i18n.middleware.should.have.been.calledWithExactly(app, {
+    expect(i18n.middleware).toHaveBeenCalledWith(app, {
       baseDir: [APP_ROOT + "/test/bootstrap/fixtures"],
       noCache: true,
       watch: true,
@@ -60,9 +65,9 @@ describe("translation middleware", () => {
 
   it("should use the i18n middleware specifying a custom allowed lang list", () => {
     translation.setup(app, { allowedLangs: ["fr"] });
-    i18n.middleware.should.have.been.calledWithExactly(
+    expect(i18n.middleware).toHaveBeenCalledWith(
       app,
-      sinon.match({
+      expect.objectContaining({
         allowedLangs: ["fr"],
       }),
     );
@@ -70,9 +75,9 @@ describe("translation middleware", () => {
 
   it("should use the i18n middleware specifying a custom cookie name", () => {
     translation.setup(app, { cookie: { name: "mycookie" } });
-    i18n.middleware.should.have.been.calledWithExactly(
+    expect(i18n.middleware).toHaveBeenCalledWith(
       app,
-      sinon.match({
+      expect.objectContaining({
         cookie: { name: "mycookie" },
       }),
     );
@@ -80,20 +85,22 @@ describe("translation middleware", () => {
 
   it("should use the i18n middleware specifying a custum query lang", () => {
     translation.setup(app, { query: "test" });
-    i18n.middleware.should.have.been.calledWithExactly(
+    expect(i18n.middleware).toHaveBeenCalledWith(
       app,
-      sinon.match({
+      expect.objectContaining({
         query: "test",
       }),
     );
   });
 
   it("should use the i18n middleware without dev flags in production", () => {
-    app.get.withArgs("dev").returns(false);
+    app.get.mockImplementation((arg) => {
+      if (arg === "dev") return false;
+    });
     translation.setup(app);
-    i18n.middleware.should.have.been.calledWithExactly(
+    expect(i18n.middleware).toHaveBeenCalledWith(
       app,
-      sinon.match({
+      expect.objectContaining({
         noCache: false,
         watch: false,
       }),

--- a/test/bootstrap/middleware/spec.version.js
+++ b/test/bootstrap/middleware/spec.version.js
@@ -1,9 +1,11 @@
+import { describe, vi, expect, beforeEach, it } from "vitest";
+
 const version = require(APP_ROOT + "/src/bootstrap/middleware/version");
 
 describe("Version", () => {
   it("exports a middleware function", () => {
-    version.middleware().should.be.a("function");
-    version.middleware().length.should.equal(3);
+    expect(typeof version.middleware()).toBe("function");
+    expect(version.middleware()).toHaveLength(3);
   });
 
   describe("middleware", () => {
@@ -12,16 +14,16 @@ describe("Version", () => {
     beforeEach(() => {
       req = {};
       res = {
-        send: sinon.stub(),
+        send: vi.fn(),
       };
-      next = sinon.stub();
+      next = vi.fn();
     });
 
     it("call res.send with the contents of version file and app name", () => {
       version.middleware()(req, res, next);
 
-      res.send.should.have.been.calledOnce;
-      res.send.should.have.been.calledWithExactly({
+      expect(res.send).toHaveBeenCalledTimes(1);
+      expect(res.send).toHaveBeenCalledWith({
         version: "1.2.3",
         foo: "bar",
         appName: "test",
@@ -34,7 +36,7 @@ describe("Version", () => {
     it("should ignore version file if not found", () => {
       version.middleware({ versionFile: "notfound.json" })(req, res, next);
 
-      res.send.should.have.been.calledWithExactly({
+      expect(res.send).toHaveBeenCalledWith({
         appName: "test",
         appVersion: "1.0.1",
         nodeVersion: String(process.versions.node),

--- a/test/bootstrap/spec.index.js
+++ b/test/bootstrap/spec.index.js
@@ -1,19 +1,23 @@
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+
 const index = require(APP_ROOT + "/src/bootstrap");
 const express = require("express");
 
 describe("hmpo-app", () => {
   it("should export setup functions and libs", () => {
-    index.should.contain.all.keys([
-      "setup",
-      "middleware",
-      "config",
-      "logger",
-      "redisClient",
-      "translation",
-      "nunjucks",
-      "linkedFiles",
-      "featureFlag",
-    ]);
+    expect(Object.keys(index)).toEqual(
+      expect.arrayContaining([
+        "setup",
+        "middleware",
+        "config",
+        "logger",
+        "redisClient",
+        "translation",
+        "nunjucks",
+        "linkedFiles",
+        "featureFlag",
+      ]),
+    );
   });
 
   describe("setup", () => {
@@ -22,8 +26,16 @@ describe("hmpo-app", () => {
     let router;
     let errorRouter;
     let publicFallbackRouter;
+    let routerSpy;
 
     beforeEach(() => {
+      const redisStub = {
+        del: vi.fn(),
+        expire: vi.fn(),
+        get: vi.fn(),
+        setex: vi.fn(),
+      };
+
       app = {
         use: sinon.stub(),
         get: sinon.stub(),
@@ -31,15 +43,18 @@ describe("hmpo-app", () => {
       };
       publicFallbackRouter = {
         use: sinon.stub(),
+        use: vi.fn(),
+        get: vi.fn(),
+        listen: vi.fn(),
       };
       staticRouter = {
-        use: sinon.stub(),
+        use: vi.fn(),
       };
       router = {
-        use: sinon.stub(),
+        use: vi.fn(),
       };
       errorRouter = {
-        use: sinon.stub(),
+        use: vi.fn(),
       };
       sinon.stub(express, "Router");
       express.Router.onCall(0).returns(staticRouter);
@@ -54,38 +69,56 @@ describe("hmpo-app", () => {
       sinon.stub(index.middleware, "session");
       sinon.stub(index.middleware, "errorHandler");
       sinon.stub(index.middleware, "listen");
+      routerSpy = vi.spyOn(express, "Router");
+      routerSpy
+        .mockReturnValueOnce(staticRouter)
+        .mockReturnValueOnce(router)
+        .mockReturnValueOnce(errorRouter);
+      vi.spyOn(index.config, "get");
+      vi.spyOn(index.config, "setup");
+      vi.spyOn(index.logger, "setup");
+      vi.spyOn(index.redisClient, "setup").mockImplementation(() => {});
+      vi.spyOn(index.redisClient, "getClient").mockReturnValue(redisStub);
+      vi.spyOn(index.middleware, "setup").mockReturnValue(app);
+      vi.spyOn(index.middleware, "session");
+      vi.spyOn(index.middleware, "errorHandler");
+      vi.spyOn(index.middleware, "listen");
     });
     afterEach(() => {
-      express.Router.restore();
-      index.config.get.restore();
-      index.config.setup.restore();
-      index.logger.setup.restore();
-      index.redisClient.setup.restore();
-      index.middleware.setup.restore();
-      index.middleware.session.restore();
-      index.middleware.errorHandler.restore();
-      index.middleware.listen.restore();
+      routerSpy.mockClear();
+      index.config.get.mockClear();
+      index.config.setup.mockClear();
+      index.logger.setup.mockClear();
+      index.redisClient.setup.mockClear();
+      index.middleware.setup.mockClear();
+      index.middleware.session.mockClear();
+      index.middleware.errorHandler.mockClear();
+      index.middleware.listen.mockClear();
     });
 
     it("calls config.setup", () => {
       index.setup();
-      index.config.setup.should.have.been.calledWithExactly(undefined);
+      expect(index.config.setup).toHaveBeenCalledWith(undefined);
     });
 
     it("calls config.setup with options", () => {
       index.setup({ config: { option: true } });
-      index.config.setup.should.have.been.calledWithExactly({ option: true });
+      expect(index.config.setup).toHaveBeenCalledWith({
+        option: true,
+      });
     });
 
     it("should not call config.setup if option is false", () => {
       index.setup({ config: false });
-      index.config.setup.should.not.have.been.called;
+      expect(index.config.setup).not.toHaveBeenCalled();
     });
 
     it("calls logger.setup with options", () => {
-      index.config.get.withArgs("logs").returns({ config: true });
+      index.config.get.mockImplementation((arg) => {
+        if (arg === "logs") return { config: true };
+      });
       index.setup({ logs: { option: true } });
-      index.logger.setup.should.have.been.calledWithExactly({
+      expect(index.logger.setup).toHaveBeenCalledWith({
         option: true,
         config: true,
       });
@@ -93,13 +126,15 @@ describe("hmpo-app", () => {
 
     it("should not call logger.setup if option is false", () => {
       index.setup({ logs: false });
-      index.logger.setup.should.not.have.been.called;
+      expect(index.logger.setup).not.toHaveBeenCalled();
     });
 
     it("calls redisClient.setup with options", () => {
-      index.config.get.withArgs("redis").returns({ config: true });
+      index.config.get.mockImplementation((arg) => {
+        if (arg === "redis") return { config: true };
+      });
       index.setup({ redis: { option: true } });
-      index.redisClient.setup.should.have.been.calledWithExactly({
+      expect(index.redisClient.setup).toHaveBeenCalledWith({
         option: true,
         config: true,
       });
@@ -107,22 +142,24 @@ describe("hmpo-app", () => {
 
     it("should not call redisClient.setup if option is false", () => {
       index.setup({ redis: false });
-      index.redisClient.setup.should.not.have.been.called;
+      expect(index.redisClient.setup).not.toHaveBeenCalled();
     });
 
     it("calls middleware.setup with options", () => {
-      index.config.get.withArgs().returns({ config: true });
+      index.config.get.mockReturnValue({ config: true });
       index.setup({ option: true });
-      index.middleware.setup.should.have.been.calledWithExactly({
+      expect(index.middleware.setup).toHaveBeenCalledWith({
         option: true,
         config: true,
       });
     });
 
     it("calls middleware.session with options", () => {
-      index.config.get.withArgs("session").returns({ config: true });
+      index.config.get.mockImplementation((arg) => {
+        if (arg === "session") return { config: true };
+      });
       index.setup({ session: { option: true } });
-      index.middleware.session.should.have.been.calledWithExactly(app, {
+      expect(index.middleware.session).toHaveBeenCalledWith(app, {
         option: true,
         config: true,
       });
@@ -130,13 +167,15 @@ describe("hmpo-app", () => {
 
     it("should not call middleware.session if option is false", () => {
       index.setup({ session: false });
-      index.middleware.session.should.not.have.been.called;
+      expect(index.middleware.session).not.toHaveBeenCalled();
     });
 
     it("calls middleware.errorHandler with options", () => {
-      index.config.get.withArgs("errors").returns({ config: true });
+      index.config.get.mockImplementation((arg) => {
+        if (arg === "errors") return { config: true };
+      });
       index.setup({ errors: { option: true } });
-      index.middleware.errorHandler.should.have.been.calledWithExactly(app, {
+      expect(index.middleware.errorHandler).toHaveBeenCalledWith(app, {
         option: true,
         config: true,
       });
@@ -144,13 +183,13 @@ describe("hmpo-app", () => {
 
     it("should not call middleware.errorHandler if option is false", () => {
       index.setup({ errors: false });
-      index.middleware.errorHandler.should.not.have.been.called;
+      expect(index.middleware.errorHandler).not.toHaveBeenCalled();
     });
 
     it("should call middlewareSetupFn if option is defined", () => {
-      const callbackStub = sinon.stub();
+      const callbackStub = vi.fn();
       index.setup({ middlewareSetupFn: callbackStub });
-      callbackStub.should.have.been.called;
+      expect(callbackStub).toHaveBeenCalled();
     });
 
     it("mounts the public 404 fallback after staticRouter", () => {
@@ -167,10 +206,13 @@ describe("hmpo-app", () => {
     });
 
     it("calls middleware.listen with options", () => {
-      index.config.get.withArgs("host").returns("hostname");
-      index.config.get.withArgs("port").returns(1234);
+      index.config.get.mockImplementation((arg) => {
+        if (arg === "host") return "hostname";
+        if (arg === "port") return 1234;
+      });
+
       index.setup({ port: 5678 });
-      index.middleware.listen.should.have.been.calledWithExactly(app, {
+      expect(index.middleware.listen).toHaveBeenCalledWith(app, {
         port: 5678,
         host: "hostname",
       });
@@ -178,12 +220,12 @@ describe("hmpo-app", () => {
 
     it("should not call middleware.listen if port is false", () => {
       index.setup({ port: false });
-      index.middleware.listen.should.not.have.been.called;
+      expect(index.middleware.listen).not.toHaveBeenCalled();
     });
 
     it("returns apps and routers", () => {
       const routers = index.setup();
-      routers.should.eql({
+      expect(routers).toEqual({
         app,
         staticRouter: staticRouter,
         router: router,

--- a/test/bootstrap/spec.index.js
+++ b/test/bootstrap/spec.index.js
@@ -37,15 +37,12 @@ describe("hmpo-app", () => {
       };
 
       app = {
-        use: sinon.stub(),
-        get: sinon.stub(),
+        use: vi.fn(),
+        get: vi.fn(),
         locals: { urls: { public: "/public", publicImages: "/public/images" } },
       };
       publicFallbackRouter = {
-        use: sinon.stub(),
         use: vi.fn(),
-        get: vi.fn(),
-        listen: vi.fn(),
       };
       staticRouter = {
         use: vi.fn(),
@@ -56,22 +53,10 @@ describe("hmpo-app", () => {
       errorRouter = {
         use: vi.fn(),
       };
-      sinon.stub(express, "Router");
-      express.Router.onCall(0).returns(staticRouter);
-      express.Router.onCall(1).returns(publicFallbackRouter);
-      express.Router.onCall(2).returns(router);
-      express.Router.onCall(3).returns(errorRouter);
-      sinon.stub(index.config, "get");
-      sinon.stub(index.config, "setup");
-      sinon.stub(index.logger, "setup");
-      sinon.stub(index.redisClient, "setup");
-      sinon.stub(index.middleware, "setup").returns(app);
-      sinon.stub(index.middleware, "session");
-      sinon.stub(index.middleware, "errorHandler");
-      sinon.stub(index.middleware, "listen");
       routerSpy = vi.spyOn(express, "Router");
       routerSpy
         .mockReturnValueOnce(staticRouter)
+        .mockReturnValueOnce(publicFallbackRouter)
         .mockReturnValueOnce(router)
         .mockReturnValueOnce(errorRouter);
       vi.spyOn(index.config, "get");
@@ -82,18 +67,10 @@ describe("hmpo-app", () => {
       vi.spyOn(index.middleware, "setup").mockReturnValue(app);
       vi.spyOn(index.middleware, "session");
       vi.spyOn(index.middleware, "errorHandler");
-      vi.spyOn(index.middleware, "listen");
+      vi.spyOn(index.middleware, "listen").mockImplementation(() => {});
     });
     afterEach(() => {
-      routerSpy.mockClear();
-      index.config.get.mockClear();
-      index.config.setup.mockClear();
-      index.logger.setup.mockClear();
-      index.redisClient.setup.mockClear();
-      index.middleware.setup.mockClear();
-      index.middleware.session.mockClear();
-      index.middleware.errorHandler.mockClear();
-      index.middleware.listen.mockClear();
+      vi.restoreAllMocks();
     });
 
     it("calls config.setup", () => {
@@ -194,15 +171,13 @@ describe("hmpo-app", () => {
 
     it("mounts the public 404 fallback after staticRouter", () => {
       index.setup();
-      app.use.getCall(0).should.have.been.calledWithExactly(staticRouter);
-      app.use
-        .getCall(1)
-        .should.have.been.calledWithExactly(publicFallbackRouter);
+      expect(app.use).toHaveBeenNthCalledWith(1, staticRouter);
+      expect(app.use).toHaveBeenNthCalledWith(2, publicFallbackRouter);
     });
 
     it("does not mount the public 404 fallback if public option is false", () => {
       index.setup({ public: false });
-      express.Router.should.have.callCount(3);
+      expect(express.Router).toHaveBeenCalledTimes(3);
     });
 
     it("calls middleware.listen with options", () => {

--- a/test/lib/locals.test.js
+++ b/test/lib/locals.test.js
@@ -1,7 +1,7 @@
+import { expect, beforeEach, afterEach, describe, it, vi } from "vitest";
+
 const express = require("express");
 const reqres = require("reqres");
-const sinon = require("sinon");
-const { expect } = require("chai");
 const { setGTM, setDeviceIntelligence } = require("../../src/lib/settings");
 const {
   getGTM,
@@ -39,7 +39,7 @@ describe("setGTM / getGTM", () => {
     req.app = app;
     const res = reqres.res();
     router(req, res, () => {
-      res.locals.should.eql({
+      expect(res.locals).toEqual({
         ga4ContainerId: "ga4ContainerIdTest",
         uaContainerId: "uaContainerIdTest",
         analyticsCookieDomain: "analyticsCookieDomainTest",
@@ -75,7 +75,7 @@ describe("setDeviceIntelligence / getDeviceIntelligence", () => {
     req.app = app;
     const res = reqres.res();
     router(req, res, () => {
-      res.locals.should.eql({
+      expect(res.locals).toEqual({
         deviceIntelligenceEnabled: true,
         deviceIntelligenceDomain: "deviceIntelligenceDomainTest",
       });
@@ -87,12 +87,16 @@ describe("getLanguageToggle middleware", () => {
   let req, res, next;
 
   beforeEach(() => {
+    vi.spyOn(logger, "error").mockImplementation(() => {});
+
     req = {
       app: {
-        get: sinon.stub(),
+        get: vi.fn(),
       },
       protocol: "https",
-      get: sinon.stub().withArgs("host").returns("example.com"), // Default behavior for host,
+      get: vi.fn().mockImplementation((args) => {
+        if (args === "host") return "example.com";
+      }), // Default behavior for host,
       originalUrl: "/test-path",
       i18n: {
         language: "en",
@@ -103,35 +107,35 @@ describe("getLanguageToggle middleware", () => {
       locals: {},
     };
 
-    next = sinon.spy();
+    next = vi.fn();
   });
 
   afterEach(() => {
-    sinon.restore(); // Restore mocked methods
+    vi.restoreAllMocks(); // Restore mocked methods
   });
 
   it("should log an error if constructing currentUrl fails", () => {
-    req.get.throws(new Error("Invalid host"));
+    req.get.mockImplementation(() => {
+      throw new Error("Invalid host");
+    });
 
     getLanguageToggle(req, res, next);
 
-    sinon.assert.calledOnce(logger.error);
-    sinon.assert.calledWithExactly(
-      logger.error,
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
       "Error constructing url for language toggle",
       "Invalid host",
     );
 
-    sinon.assert.calledOnce(next);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("should set res.locals.currentUrl to the correct value", () => {
     getLanguageToggle(req, res, next);
-    expect(res.locals.currentUrl).to.be.an.instanceof(URL); // Check type
-    expect(res.locals.currentUrl.href).to.equal(
-      "https://example.com/test-path",
-    );
 
-    sinon.assert.calledOnce(next);
+    expect(res.locals.currentUrl).toBeInstanceOf(URL); // Check type
+    expect(res.locals.currentUrl.href).toEqual("https://example.com/test-path");
+
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -1,27 +1,17 @@
-const chai = require("chai");
-const sinon = require("sinon");
-const sinonChai = require("sinon-chai");
-const chaiAsPromised = require("chai-as-promised");
+import { vi } from "vitest";
+
 const reqres = require("reqres");
 const JourneyModel = require("hmpo-form-wizard/lib/journey-model");
 const WizardModel = require("hmpo-form-wizard/lib/wizard-model.js");
 
-chai.should();
-chai.use(sinonChai);
-chai.use(chaiAsPromised);
-const expect = chai.expect;
-
-global.sinon = sinon;
-global.expect = expect;
-
-global.setupDefaultMocks = () => {
+export const createDefaultReqResNext = () => {
   const req = reqres.req({
     form: {
       options: {
         fields: {},
       },
     },
-    customFetch: sinon.stub(),
+    customFetch: vi.fn(),
   });
 
   req.journeyModel = new JourneyModel(null, {
@@ -37,7 +27,8 @@ global.setupDefaultMocks = () => {
   });
 
   const res = reqres.res({});
-  const next = sinon.fake();
+  res.redirect = vi.fn();
+  const next = vi.fn();
   return {
     req,
     res,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
     include: ["test/**/*.test.js", "**/*.test.js", "**/spec*.js"],
     setupFiles: ["./test/utils/helpers.js", "./test/bootstrap/helper.js"],
     coverage: {
+      provider: "v8",
+      reporters: ["text", "lcov"],
       include: ["src/**/*"],
+      exclude: ["**/*.njk", "**/*.md"],
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    clearMocks: true,
+    include: ["test/**/*.test.js", "**/*.test.js", "**/spec*.js"],
+    setupFiles: ["./test/utils/helpers.js", "./test/bootstrap/helper.js"],
+    coverage: {
+      include: ["src/**/*"],
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     setupFiles: ["./test/utils/helpers.js", "./test/bootstrap/helper.js"],
     coverage: {
       provider: "v8",
-      reporters: ["text", "lcov"],
+      reporter: ["text", "lcov"],
       include: ["src/**/*"],
       exclude: ["**/*.njk", "**/*.md"],
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Changed all sinon/chai assertions to use vitest assertions
- Updated the mocha-helper file to use the vitest equivalent helper file 
- Removed done from all the test and updated it to use async 
- Updated the `setTimeout` and `setImmediate` to use vitest `vi.waitFor`
- Updated a few tests based on code smells

### Why did it change

Currently, frontend repositories of the CRI’s Orange maintains have a diverse range of test setups. To reduce the significant overhead this presents, 
[OJ-3619 - Investigate common FE testing technology](https://govukverify.atlassian.net/wiki/spaces/OJ/pages/6465421501/OJ-3619+-+Investigate+common+FE+testing+technology) was completed.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- OJ-3673

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
